### PR TITLE
feat: support tag exclusion in tag search using - prefix

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/search/domain/SearchV2Helper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/search/domain/SearchV2Helper.kt
@@ -114,7 +114,7 @@ class SearchV2Helper @AssistedInject constructor(
 			}
 
 			SearchKind.TAG -> sortByDescending { m ->
-				val queryExcludeTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] == "-"}
+				val queryExcludeTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] == '-'}
 				val queryTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] != '-'}
 				m.tags.count { tag -> queryTagsStr.any { q -> tag.title.equals(q, ignoreCase = true) } } - m.tags.count { tag -> queryExcludeTagsStr.any { q -> tag.title.equals(q.substring(1), ignoreCase = true) } }
 			}

--- a/app/src/main/kotlin/org/skepsun/kototoro/search/domain/SearchV2Helper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/search/domain/SearchV2Helper.kt
@@ -66,13 +66,18 @@ class SearchV2Helper @AssistedInject constructor(
 				e.printStackTraceDebug()
 			}.getOrDefault(emptySet())
 			
-			val queryTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+			val queryExcludeTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] == '-' }
+			val matchedExcludeTags = queryExcludeTagsStr.mapNotNull { tagQ -> 
+				val newTagQ = tagQ.substring(1)
+				tags.find { x -> x.title.equals(newTagQ, ignoreCase = true) }
+			}.toSet()
+			val queryTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] != '-'}
 			val matchedTags = queryTagsStr.mapNotNull { tagQ -> 
 				tags.find { x -> x.title.equals(tagQ, ignoreCase = true) }
 			}.toSet()
 			
-			if (matchedTags.isNotEmpty()) {
-				ContentListFilter(tags = matchedTags)
+			if (matchedTags.isNotEmpty() || matchedExcludeTags.isNotEmpty()) {
+				ContentListFilter(tags = matchedTags, tagsExclude = matchedExcludeTags)
 			} else {
 				null
 			}
@@ -109,8 +114,9 @@ class SearchV2Helper @AssistedInject constructor(
 			}
 
 			SearchKind.TAG -> sortByDescending { m ->
-				val queryTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-				m.tags.count { tag -> queryTagsStr.any { q -> tag.title.equals(q, ignoreCase = true) } }
+				val queryExcludeTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] == "-"}
+				val queryTagsStr = query.split(",").map { it.trim() }.filter { it.isNotEmpty() && it[0] != '-'}
+				m.tags.count { tag -> queryTagsStr.any { q -> tag.title.equals(q, ignoreCase = true) } } - m.tags.count { tag -> queryExcludeTagsStr.any { q -> tag.title.equals(q.substring(1), ignoreCase = true) } }
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Add support for excluding tags in tag search by prefixing them with `-`.

## Changes

- **`SearchV2Helper.kt`**: Updated `getFilter()` to parse tags prefixed with `-` as exclude tags, matching them against available tags and passing them via `ContentListFilter(tagsExclude = ...)`. Updated `sortByRelevance()` to penalize results that match excluded tags.

## Usage

When searching by tag, users can now combine include and exclude tags:
- `action, -romance` → include *action*, exclude *romance*
- `-horror, comedy` → exclude *horror*, include *comedy*

## Validation

- `./gradlew :app:compileDebugKotlin --no-daemon` → **BUILD SUCCESSFUL**
- `./gradlew :app:testDebugUnitTest --no-daemon` → test compilation fails due to pre-existing errors in `ReaderOcrPipelineCoordinatorTest.kt` (unrelated to this PR)
