### PR TITLE
GIF Support in mangas images and support for AVIS GIF

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/image/AvifAnimatedDrawable.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/image/AvifAnimatedDrawable.kt
@@ -1,0 +1,131 @@
+package org.skepsun.kototoro.core.image
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.drawable.Animatable
+import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Drawable that plays back an AVIF image sequence (AVIS) from pre-decoded frames.
+ *
+ * Exists because the platform AnimatedImageDecoder does not reliably drive AVIS, and
+ * just-in-time per-frame libavif decoding on a ~1K page stutters (AV1 decode cost exceeds
+ * the frame budget). The caller is expected to decode every frame up front so playback is
+ * just a bitmap swap — no work on the main thread during a frame.
+ */
+class AvifAnimatedDrawable(
+	private val frames: List<Bitmap>,
+	private val frameDurationsMs: LongArray,
+	// libavif semantics: >0 = finite loop count, anything else = loop forever.
+	repetitionCount: Int,
+) : Drawable(), Animatable, Runnable {
+
+	init {
+		require(frames.isNotEmpty()) { "AvifAnimatedDrawable requires at least one frame" }
+		require(frameDurationsMs.size == frames.size) {
+			"frameDurationsMs.size=${frameDurationsMs.size} must match frames.size=${frames.size}"
+		}
+	}
+
+	private val paint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.DITHER_FLAG)
+	private val intrinsicW = frames[0].width
+	private val intrinsicH = frames[0].height
+	private val handler = Handler(Looper.getMainLooper())
+	private val running = AtomicBoolean(false)
+	private val finiteLoops = repetitionCount.takeIf { it > 0 }
+
+	private var currentFrame = 0
+	private var loopsDone = 0
+	private var disposed = false
+
+	override fun draw(canvas: Canvas) {
+		if (disposed) return
+		val frame = frames.getOrNull(currentFrame) ?: return
+		if (!frame.isRecycled) {
+			canvas.drawBitmap(frame, null, bounds, paint)
+		}
+	}
+
+	override fun setAlpha(alpha: Int) {
+		paint.alpha = alpha
+	}
+
+	override fun setColorFilter(colorFilter: ColorFilter?) {
+		paint.colorFilter = colorFilter
+	}
+
+	@Deprecated("Deprecated in Java")
+	override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+
+	override fun getIntrinsicWidth(): Int = intrinsicW
+	override fun getIntrinsicHeight(): Int = intrinsicH
+
+	override fun start() {
+		if (disposed || frames.size <= 1) return
+		if (!running.compareAndSet(false, true)) return
+		scheduleNextFrame()
+	}
+
+	override fun stop() {
+		if (!running.compareAndSet(true, false)) return
+		handler.removeCallbacks(this)
+	}
+
+	override fun isRunning(): Boolean = running.get()
+
+	/**
+	 * Ties playback to the host view's visibility so the drawable stops burning battery
+	 * while scrolled off-screen, and resumes automatically when it comes back.
+	 */
+	override fun setVisible(visible: Boolean, restart: Boolean): Boolean {
+		val changed = super.setVisible(visible, restart)
+		if (visible) {
+			if (restart || !running.get()) start()
+		} else {
+			stop()
+		}
+		return changed
+	}
+
+	override fun run() {
+		if (!running.get() || disposed) return
+		val nextIndex = currentFrame + 1
+		currentFrame = if (nextIndex >= frames.size) {
+			loopsDone++
+			val cap = finiteLoops
+			if (cap != null && loopsDone >= cap) {
+				running.set(false)
+				return
+			}
+			0
+		} else {
+			nextIndex
+		}
+		invalidateSelf()
+		scheduleNextFrame()
+	}
+
+	private fun scheduleNextFrame() {
+		val delay = frameDurationsMs[currentFrame].coerceAtLeast(MIN_FRAME_DELAY_MS)
+		handler.postAtTime(this, SystemClock.uptimeMillis() + delay)
+	}
+
+	fun release() {
+		if (disposed) return
+		disposed = true
+		stop()
+		frames.forEach { if (!it.isRecycled) it.recycle() }
+	}
+
+	companion object {
+		// Clamp below this to avoid busy-looping on malformed duration metadata.
+		private const val MIN_FRAME_DELAY_MS = 16L
+	}
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/image/AvifImageDecoder.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/image/AvifImageDecoder.kt
@@ -37,6 +37,25 @@ class AvifImageDecoder(
 			} else {
 				Bitmap.Config.RGB_565
 			}
+			// Animated AVIF (AVIS): decode every frame up front so playback is just a
+			// bitmap swap. Per-frame JIT decoding of AV1 is too slow on typical devices
+			// to hold the nominal frame rate — decoding all frames once trades a longer
+			// initial decode + memory for smooth playback and no main-thread CPU during
+			// animation. Falls back to the static path if the total would exceed the
+			// memory budget (guards against pathological sequences / OOM).
+			if (decoder.frameCount > 1) {
+				val animated = tryDecodeAllFrames(decoder, config)
+				if (animated != null) {
+					return@runInterruptible DecodeResult(
+						// shareable = false: the drawable owns native bitmaps that will
+						// be recycled via release(); it must not be served from Coil's
+						// memory cache to a second consumer after the first disposes it.
+						image = animated.asImage(shareable = false),
+						isSampled = false,
+					)
+				}
+				// Budget exceeded — fall through to static first-frame rendering.
+			}
 			val bitmap = createBitmap(decoder.width, decoder.height, config)
 			val result = decoder.nextFrame(bitmap)
 			if (result != 0) {
@@ -73,6 +92,51 @@ class AvifImageDecoder(
 		}
 	}
 
+	private fun tryDecodeAllFrames(
+		decoder: AvifDecoder,
+		config: Bitmap.Config,
+	): AvifAnimatedDrawable? {
+		val frameCount = decoder.frameCount
+		val bytesPerPixel = if (config == Bitmap.Config.ARGB_8888) 4 else 2
+		val totalBytes = frameCount.toLong() * decoder.width * decoder.height * bytesPerPixel
+		if (totalBytes > ANIMATED_MEMORY_BUDGET_BYTES) return null
+
+		val rawDurations = decoder.frameDurations
+		val durationsMs = LongArray(frameCount) { idx ->
+			val secs = rawDurations?.getOrNull(idx) ?: DEFAULT_FRAME_DURATION_SEC
+			(secs * 1000.0).toLong()
+		}
+		val repetitionCount = decoder.repetitionCount
+		val frames = ArrayList<Bitmap>(frameCount)
+		try {
+			for (i in 0 until frameCount) {
+				val bitmap = createBitmap(decoder.width, decoder.height, config)
+				val result = decoder.nthFrame(i, bitmap)
+				if (result != 0) {
+					bitmap.recycle()
+					frames.forEach { it.recycle() }
+					throw ImageDecodeException(
+						uri = source.fileOrNull()?.toString(),
+						format = "avif",
+						message = AvifDecoder.resultToString(result),
+					)
+				}
+				frames.add(bitmap)
+			}
+		} catch (e: Throwable) {
+			frames.forEach { if (!it.isRecycled) it.recycle() }
+			throw e
+		}
+		return AvifAnimatedDrawable(frames, durationsMs, repetitionCount)
+	}
+
+	private companion object {
+		private const val DEFAULT_FRAME_DURATION_SEC = 0.042
+
+		
+		private const val ANIMATED_MEMORY_BUDGET_BYTES = 1000L * 1024 * 1024
+	}
+
 	class Factory : Decoder.Factory {
 
 		override fun create(
@@ -90,7 +154,22 @@ class AvifImageDecoder(
 		override fun hashCode() = javaClass.hashCode()
 
 		private fun isApplicable(result: SourceFetchResult): Boolean {
-			return result.mimeType == "image/avif"
+			if (result.mimeType == "image/avif") return true
+			// File sources loaded from cache often have no mime type propagated.
+			// Fall back to probing the ftyp box so AVIF/AVIS files are still routed here
+			// instead of the platform decoder (which mis-renders AVIS on API 12).
+			return try {
+				result.source.source().peek().use { peek ->
+					if (!peek.request(12L)) return@use false
+					val header = peek.readByteArray(minOf(32L, peek.buffer.size))
+					header.size >= 12 &&
+						header[4] == 'f'.code.toByte() && header[5] == 't'.code.toByte() &&
+						header[6] == 'y'.code.toByte() && header[7] == 'p'.code.toByte() &&
+						String(header, 8, 4).let { it == "avif" || it == "avis" }
+				}
+			} catch (_: Exception) {
+				false
+			}
 		}
 	}
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/image/BitmapDecoderCompat.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/image/BitmapDecoderCompat.kt
@@ -72,6 +72,64 @@ object BitmapDecoderCompat {
 	}
 
 	@Blocking
+	fun isAnimated(file: File): Boolean {
+		if (!file.exists()) return false
+		return try {
+			file.inputStream().use { stream ->
+				val header = ByteArray(1024)
+				val n = stream.read(header)
+				if (n < 6) return false
+				isAnimatedHeader(header, n)
+			}
+		} catch (_: Exception) {
+			false
+		}
+	}
+
+	private fun isAnimatedHeader(h: ByteArray, n: Int): Boolean {
+		// GIF87a / GIF89a
+		if (h[0] == 'G'.code.toByte() && h[1] == 'I'.code.toByte() && h[2] == 'F'.code.toByte()) {
+			return true
+		}
+		// Animated WebP: RIFF....WEBPVP8X with animation flag bit
+		if (n >= 21 &&
+			h[0] == 'R'.code.toByte() && h[1] == 'I'.code.toByte() &&
+			h[2] == 'F'.code.toByte() && h[3] == 'F'.code.toByte() &&
+			h[8] == 'W'.code.toByte() && h[9] == 'E'.code.toByte() &&
+			h[10] == 'B'.code.toByte() && h[11] == 'P'.code.toByte() &&
+			h[12] == 'V'.code.toByte() && h[13] == 'P'.code.toByte() &&
+			h[14] == '8'.code.toByte() && h[15] == 'X'.code.toByte() &&
+			(h[20].toInt() and 0x02) != 0
+		) return true
+		// Animated AVIF: ftyp box with major brand "avis" or compatible brand "avis"
+		if (n >= 12 &&
+			h[4] == 'f'.code.toByte() && h[5] == 't'.code.toByte() &&
+			h[6] == 'y'.code.toByte() && h[7] == 'p'.code.toByte()
+		) {
+			if (n >= 12 && String(h, 8, 4) == "avis") return true
+			val numCompatible = (n - 16) / 4
+			for (i in 0 until numCompatible) {
+				val off = 16 + i * 4
+				if (off + 4 <= n && String(h, off, 4) == "avis") return true
+			}
+		}
+		// APNG: PNG magic bytes + acTL chunk somewhere in first 1024 bytes
+		if (n >= 8 &&
+			h[0] == 0x89.toByte() && h[1] == 0x50.toByte() &&
+			h[2] == 0x4E.toByte() && h[3] == 0x47.toByte() &&
+			h[4] == 0x0D.toByte() && h[5] == 0x0A.toByte() &&
+			h[6] == 0x1A.toByte() && h[7] == 0x0A.toByte()
+		) {
+			for (i in 8 until n - 4) {
+				if (h[i] == 'a'.code.toByte() && h[i + 1] == 'c'.code.toByte() &&
+					h[i + 2] == 'T'.code.toByte() && h[i + 3] == 'L'.code.toByte()
+				) return true
+			}
+		}
+		return false
+	}
+
+	@Blocking
 	fun probeMimeType(file: File): MimeType? {
 		return MimeTypes.probeMimeType(file) ?: detectBitmapType(file)
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/PageLoader.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/PageLoader.kt
@@ -94,7 +94,7 @@ class PageLoader @Inject constructor(
 	lifecycle: ActivityRetainedLifecycle,
 	@ContentHttpClient private val okHttp: OkHttpClient,
 	@PageCache private val cache: LocalStorageCache,
-	private val coil: ImageLoader,
+	val imageLoader: ImageLoader,
 	private val settings: AppSettings,
 	private val mangaRepositoryFactory: ContentRepository.Factory,
 	private val imageProxyInterceptor: ImageProxyInterceptor,
@@ -161,14 +161,14 @@ class PageLoader @Inject constructor(
 			.mangaSourceExtra(page.source)
 			.transformations(TrimTransformation())
 			.build()
-		return coil.execute(request).image?.toImageSource()
+		return imageLoader.execute(request).image?.toImageSource()
 	}
 
 	fun peekPreviewSource(preview: String?): ImageSource? {
 		if (preview.isNullOrEmpty()) {
 			return null
 		}
-		coil.memoryCache?.let { cache ->
+		imageLoader.memoryCache?.let { cache ->
 			val key = MemoryCache.Key(preview)
 			cache[key]?.image?.let {
 				return if (it is BitmapImage) {
@@ -178,7 +178,7 @@ class PageLoader @Inject constructor(
 				}
 			}
 		}
-		coil.diskCache?.let { cache ->
+		imageLoader.diskCache?.let { cache ->
 			cache.openSnapshot(preview)?.use { snapshot ->
 				return ImageSource.file(snapshot.data.toFile())
 			}

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/BasePageHolder.kt
@@ -4,14 +4,23 @@ import android.content.ComponentCallbacks2
 import android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE
 import android.content.Context
 import android.content.res.Configuration
+import android.net.Uri
 import android.view.View
+import android.widget.ImageView
 import androidx.annotation.CallSuper
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.viewbinding.ViewBinding
+import android.graphics.drawable.Animatable
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.request.target
+import coil3.size.Size
+import coil3.util.CoilUtils
 import com.davemorrissey.labs.subscaleview.DefaultOnImageEventListener
+import com.davemorrissey.labs.subscaleview.ImageSource
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -53,6 +62,7 @@ abstract class BasePageHolder<B : ViewBinding>(
 	)
 	protected val bindingInfo = LayoutPageInfoBinding.bind(binding.root)
 	protected abstract val ssiv: SubsamplingScaleImageView
+	protected abstract val animatedView: ImageView
 
 	protected val settings: ReaderSettings
 		get() = viewModel.settingsProducer.value
@@ -64,6 +74,7 @@ abstract class BasePageHolder<B : ViewBinding>(
 		private set
 	private var lastTranslationDisplaySignature: String? = null
 	private var lastTranslationContentSignature: String? = null
+	private var pendingAnimatedUri: Uri? = null
 
 	init {
 		lifecycleScope.launch(Dispatchers.Main) {
@@ -147,11 +158,23 @@ abstract class BasePageHolder<B : ViewBinding>(
 		if (viewModel.state.value is PageState.Error && !viewModel.isLoading()) {
 			boundData?.let { viewModel.retry(it.toContentPage(), isFromUser = false) }
 		}
+		val uri = pendingAnimatedUri ?: return
+		val current = animatedView.drawable
+		if (current == null) {
+			// Holder just became the current page — kick off the deferred animated decode now.
+			enqueueAnimated(uri)
+		} else {
+			(current as? Animatable)?.let { if (!it.isRunning) it.start() }
+		}
 	}
 
 	override fun onPause() {
 		super.onPause()
 		ssiv.applyDownSampling(isForeground = false)
+		// Adjacent (offscreen) holders are technically attached to the window, so the
+		// drawable's own setVisible(false) hook won't fire. Stop here to keep the frame
+		// timer from running on pages the user can't see.
+		(animatedView.drawable as? Animatable)?.stop()
 	}
 
 	override fun onDestroy() {
@@ -166,7 +189,12 @@ abstract class BasePageHolder<B : ViewBinding>(
 	@CallSuper
 	open fun onRecycled() {
 		viewModel.onRecycle()
+		ssiv.isVisible = true
 		ssiv.recycle()
+		pendingAnimatedUri = null
+		releaseAnimatedDrawable()
+		CoilUtils.dispose(animatedView)
+		animatedView.isVisible = false
 	}
 
 	override fun onTrimMemory(level: Int) {
@@ -214,6 +242,16 @@ abstract class BasePageHolder<B : ViewBinding>(
 			}
 
 			is PageState.Loaded -> {
+				// Reset view visibility in case this holder just showed an animated page
+				// (without this the animatedView can linger with stale content when the
+				// holder is reused across pages of different formats).
+				if (animatedView.isVisible) {
+					pendingAnimatedUri = null
+					releaseAnimatedDrawable()
+					CoilUtils.dispose(animatedView)
+					animatedView.isVisible = false
+				}
+				ssiv.isVisible = true
 				bindingInfo.textViewStatus.setText(R.string.preparing_)
 				ssiv.setImage(state.source)
 			}
@@ -224,8 +262,60 @@ abstract class BasePageHolder<B : ViewBinding>(
 				}
 			}
 
-			is PageState.Shown -> Unit
+			is PageState.Shown -> {
+				if (state.isAnimated) {
+					prepareAnimated((state.source as? ImageSource.Uri)?.uri ?: return)
+				}
+			}
 		}
+	}
+
+	private fun releaseAnimatedDrawable() {
+		(animatedView.drawable as? org.skepsun.kototoro.core.image.AvifAnimatedDrawable)?.release()
+	}
+
+	private fun prepareAnimated(uri: Uri) {
+		// Always swap the views so the layout is consistent — but defer the heavy
+		// libavif full-sequence decode until this holder is actually the current page.
+		// Adjacent holders (offscreen page limit > 0) get bound and would otherwise
+		// decode every frame of an AVIS in the background, which is the main source
+		// of stutter while the user is sitting on a different page.
+		pendingAnimatedUri = uri
+		ssiv.recycle()
+		ssiv.isVisible = false
+		animatedView.isVisible = true
+		if (isResumed()) {
+			enqueueAnimated(uri)
+		} else {
+			// Drop any stale drawable from a previous binding so we don't show wrong frames
+			// briefly when the user lands on this page.
+			releaseAnimatedDrawable()
+			CoilUtils.dispose(animatedView)
+			animatedView.setImageDrawable(null)
+		}
+	}
+
+	private fun enqueueAnimated(uri: Uri) {
+		releaseAnimatedDrawable()
+		CoilUtils.dispose(animatedView)
+		viewModel.imageLoader.enqueue(
+			ImageRequest.Builder(context)
+				.data(uri)
+				.target(animatedView)
+				// Size.ORIGINAL preserves intrinsic dimensions; any scaling is delegated to the ImageView's fitCenter.
+				.size(Size.ORIGINAL)
+				// AnimatedImageDrawable cannot be backed by an immutable hardware bitmap;
+				// without this the first frame is decoded as a hardware bitmap and playback never starts.
+				.allowHardware(false)
+				.listener(
+					onSuccess = { _, _ ->
+						(animatedView.drawable as? Animatable)?.let { anim ->
+							if (!anim.isRunning) anim.start()
+						}
+					},
+				)
+				.build(),
+		)
 	}
 
 	protected fun SubsamplingScaleImageView.applyDownSampling(isForeground: Boolean) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/standard/PageHolder.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/standard/PageHolder.kt
@@ -57,6 +57,7 @@ open class PageHolder(
 ), ZoomControl.ZoomControlListener, OnApplyWindowInsetsListener {
 
 	override val ssiv = binding.ssiv
+	override val animatedView = binding.imageViewAnimated
 	private val holderScope: CoroutineScope = owner.lifecycleScope
 	private val ssivOriginal = binding.ssivOriginal
 	private var dualLayerLoadJob: Job? = null
@@ -122,10 +123,8 @@ open class PageHolder(
 	override fun onStateChanged(state: org.skepsun.kototoro.reader.ui.pager.vm.PageState) {
 		super.onStateChanged(state)
 		when (state) {
-			is org.skepsun.kototoro.reader.ui.pager.vm.PageState.Loaded,
-			is org.skepsun.kototoro.reader.ui.pager.vm.PageState.Shown,
-			-> refreshDualLayers()
-
+			is org.skepsun.kototoro.reader.ui.pager.vm.PageState.Loaded -> refreshDualLayers()
+			is org.skepsun.kototoro.reader.ui.pager.vm.PageState.Shown -> if (!state.isAnimated) refreshDualLayers()
 			else -> Unit
 		}
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/vm/PageState.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/vm/PageState.kt
@@ -26,6 +26,7 @@ sealed class PageState {
 	data class Shown(
 		val source: ImageSource,
 		val isConverted: Boolean,
+		val isAnimated: Boolean = false,
 	) : PageState()
 
 	data class Error(

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/vm/PageViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/vm/PageViewModel.kt
@@ -3,6 +3,8 @@ package org.skepsun.kototoro.reader.ui.pager.vm
 import android.graphics.Rect
 import android.net.Uri
 import androidx.annotation.WorkerThread
+import androidx.core.net.toFile
+import coil3.ImageLoader
 import com.davemorrissey.labs.subscaleview.DefaultOnImageEventListener
 import com.davemorrissey.labs.subscaleview.ImageSource
 import kotlinx.coroutines.CancellationException
@@ -22,7 +24,10 @@ import kotlinx.coroutines.withContext
 import okio.IOException
 import android.graphics.BitmapFactory
 import org.skepsun.kototoro.core.exceptions.resolve.ExceptionResolver
+import org.skepsun.kototoro.core.image.BitmapDecoderCompat
 import org.skepsun.kototoro.core.os.NetworkState
+import org.skepsun.kototoro.core.util.ext.isFileUri
+import org.skepsun.kototoro.parsers.util.runCatchingCancellable
 import org.skepsun.kototoro.core.util.ext.printStackTraceDebug
 import org.skepsun.kototoro.core.util.ext.throttle
 import org.skepsun.kototoro.parsers.model.ContentPage
@@ -66,6 +71,7 @@ class PageViewModel(
 			}.launchIn(scope)
 	}
 
+	val imageLoader: ImageLoader get() = loader.imageLoader
 	val state = MutableStateFlow<PageState>(PageState.Empty)
 
 	fun isLoading() = job?.isActive == true
@@ -227,11 +233,17 @@ class PageViewModel(
 				currentUri = uri,
 				showTranslated = settingsProducer.value.isTranslationShowTranslated,
 			) ?: uri
-			cachedBounds = resolveTrimmedBounds(displayUri)
-			state.value = if (settingsProducer.value.isTranslationEnabled && settingsProducer.value.isTranslationShowTranslated && displayUri == uri) {
-				PageState.AwaitingTranslation(displayUri.toImageSource(cachedBounds), isConverted = false)
+			val isAnimated = displayUri.isFileUri() &&
+				runCatchingCancellable { BitmapDecoderCompat.isAnimated(displayUri.toFile()) }.getOrDefault(false)
+			if (isAnimated) {
+				state.value = PageState.Shown(displayUri.toImageSource(null), isConverted = false, isAnimated = true)
 			} else {
-				PageState.Loaded(displayUri.toImageSource(cachedBounds), isConverted = false)
+				cachedBounds = resolveTrimmedBounds(displayUri)
+				state.value = if (settingsProducer.value.isTranslationEnabled && settingsProducer.value.isTranslationShowTranslated && displayUri == uri) {
+					PageState.AwaitingTranslation(displayUri.toImageSource(cachedBounds), isConverted = false)
+				} else {
+					PageState.Loaded(displayUri.toImageSource(cachedBounds), isConverted = false)
+				}
 			}
 			applyPendingLayerSwitchIfNeeded(data, displayUri)
 		} catch (e: CancellationException) {
@@ -307,8 +319,9 @@ class PageViewModel(
 		if (uri.scheme == "file" && path != null) {
 			options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
 			BitmapFactory.decodeFile(path, options)
-			// Threshold of 1.15 to consider as a double page
-			if (options.outWidth > options.outHeight * 1.15) {
+			// outWidth/outHeight are -1 for formats BitmapFactory can't probe (e.g. AVIF).
+			// Guard > 0 to avoid false wide-page detection: -1 > -1*1.15 would otherwise be true.
+			if (options.outWidth > 0 && options.outHeight > 0 && options.outWidth > options.outHeight * 1.15) {
 				boundPage?.let { loader.widePageDetectedEvent.tryEmit(it.id) }
 			}
 		}
@@ -329,7 +342,8 @@ class PageViewModel(
 			}
 		} else null
 
-		val baseBounds = cropBounds ?: options?.let { Rect(0, 0, it.outWidth, it.outHeight) }
+		// Only create baseBounds when BitmapFactory returned valid dimensions (> 0).
+		val baseBounds = cropBounds ?: options?.let { if (it.outWidth > 0 && it.outHeight > 0) Rect(0, 0, it.outWidth, it.outHeight) else null }
 		if (baseBounds != null && boundPageSplit != org.skepsun.kototoro.reader.ui.pager.ReaderPageSplit.NONE) {
 			val halfWidth = baseBounds.width() / 2
 			return if (boundPageSplit == org.skepsun.kototoro.reader.ui.pager.ReaderPageSplit.LEFT) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/webtoon/WebtoonHolder.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/pager/webtoon/WebtoonHolder.kt
@@ -29,6 +29,7 @@ class WebtoonHolder(
 ) {
 
 	override val ssiv = binding.ssiv
+	override val animatedView = binding.imageViewAnimated
 
 	private var scrollToRestore = 0
 

--- a/app/src/main/res/layout/item_page.xml
+++ b/app/src/main/res/layout/item_page.xml
@@ -26,6 +26,14 @@
 		app:doubleTapZoomStyle="center"
 		app:restoreStrategy="deferred" />
 
+	<ImageView
+		android:id="@+id/imageViewAnimated"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:scaleType="fitCenter"
+		android:visibility="gone"
+		android:importantForAccessibility="no" />
+
 	<TextView
 		android:id="@+id/textView_number"
 		android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_page_webtoon.xml
+++ b/app/src/main/res/layout/item_page_webtoon.xml
@@ -16,6 +16,15 @@
 		app:quickScaleEnabled="false"
 		app:zoomEnabled="false" />
 
+	<ImageView
+		android:id="@+id/imageViewAnimated"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:scaleType="fitCenter"
+		android:adjustViewBounds="true"
+		android:visibility="gone"
+		android:importantForAccessibility="no" />
+
 	<include layout="@layout/layout_page_info" />
 
 </org.skepsun.kototoro.reader.ui.pager.webtoon.WebtoonFrameLayout>


### PR DESCRIPTION
## Summary

Add support for animated gifs and animated AVIF file (AVIS) in manga images.

## Changes

### 1. Animated AVIF (AVIS) Decoder & Playback
- **`AvifAnimatedDrawable`**: Created a new custom `Drawable` dedicated to playing pre-decoded AVIF sequences. This prevents stuttering and main-thread CPU spikes during animation, as just-in-time (JIT) per-frame AV1 decoding is too costly.
- **Upfront Frame Decoding**: Updated `AvifImageDecoder` to decode all frames at once when an animated image is detected, returning the new `AvifAnimatedDrawable`.
- **Memory Budget**: Implemented a memory limit (`ANIMATED_MEMORY_BUDGET_BYTES` of ~1GB) to prevent Out of Memory (OOM) errors on pathological/long sequences. If the budget is exceeded, it falls back to rendering just the first static frame.
- **Reliable Format Detection**: Improved the decoder's `Factory` to inspect the file header bytes (`ftyp` box) so that AVIF/AVIS files loaded from cache without a propagated MIME type are still routed correctly.

### 2. Fast Header Detection for Animated Images
- **``BitmapDecoderCompat.isAnimated``**: Added a fast, optimized method to identify if an image is animated by reading its magic bytes (file header) before attempting to load it fully. Supports detecting:
  - GIF (`GIF87a`, `GIF89a`)
  - Animated WebP (`RIFF...WEBPVP8X`)
  - Animated AVIF (`avis` brand)
  - APNG (`acTL` chunk)

### 3. Reader ViewModels & State Management
- **``PageState.Shown``**: Added an `isAnimated: Boolean` property to propagate the animation state to the UI layer.
- **Unknown Dimensions Bug Fix**: Fixed an issue in `PageViewModel` where formats that `BitmapFactory` cannot probe (like AVIF, which return `-1` for dimensions) caused false "wide page" or "double page" detections. Now it strictly requires dimensions to be `> 0`.
- **ImageLoader Exposure**: Made the Coil `ImageLoader` inside `PageLoader` publicly accessible so the UI layer can use it to enqueue animated image requests.

### 4. UI Support & Lifecycle Management for Animated Views
- **New Animated Views**: Added a dedicated `ImageView` (`imageViewAnimated`) to both ``item_page.xml`` and ``item_page_webtoon.xml`` specifically for displaying animated formats.
- **`BasePageHolder` Lifecycle Management**: 
  - Added logic to pause animations when holders go off-screen (`onPause`), saving battery life and system resources.
  - Optimized the heavy Coil animation loading to defer decoding until the holder becomes the user's current page. Adjacent off-screen holders only prepare the view (`pendingAnimatedUri`) to prevent stuttering.
- **Holder Implementations**: Updated `PageHolder` and `WebtoonHolder` to bind the new `animatedView` and handle the visibility toggle between it and the standard `SubsamplingScaleImageView` (which remains in use for static pages).

## Validation

- `./gradlew :app:compileDebugKotlin --no-daemon` → **BUILD SUCCESSFUL**
- `Manga from different sources tested manually` → **ALL FINE (just some slowness when loading AVIS gif)**
