### PR TITLE
Alternative feed that shows retroactively added entries from migrated backups

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
@@ -795,6 +795,10 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		get() = prefs.getBoolean(KEY_FEED_HEADER, true)
 		set(value) = prefs.edit { putBoolean(KEY_FEED_HEADER, value) }
 
+	var showAllUpdates: Boolean
+		get() = prefs.getBoolean(KEY_SHOW_ALL_UPDATES, false)
+		set(value) = prefs.edit { putBoolean(KEY_SHOW_ALL_UPDATES, value) }
+
 	var progressIndicatorMode: ProgressIndicatorMode
 		get() = prefs.getEnumValue(KEY_PROGRESS_INDICATORS, ProgressIndicatorMode.PERCENT_READ)
 		set(value) = prefs.edit { putEnumValue(KEY_PROGRESS_INDICATORS, value) }
@@ -2301,6 +2305,7 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		const val KEY_PAGES_SAVE_ASK = "pages_dir_ask"
 		const val KEY_STATS_ENABLED = "stats_on"
 		const val KEY_FEED_HEADER = "feed_header"
+		const val KEY_SHOW_ALL_UPDATES = "show_all_updates"
 		const val KEY_SEARCH_SUGGESTION_TYPES = "search_suggest_types"
 		const val KEY_SOURCES_VERSION = "sources_version"
 		const val KEY_SOURCES_ENABLED_ALL = "sources_enabled_all"

--- a/app/src/main/kotlin/org/skepsun/kototoro/list/domain/ContentListMapper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/list/domain/ContentListMapper.kt
@@ -207,7 +207,7 @@ class ContentListMapper @Inject constructor(
 			metadataSelection = dataRepository.getMetadataSourceSelection(logItem.manga.id),
 			trackingDetailsCache = HashMap(1),
 		),
-		count = logItem.chapters.size,
+		count = logItem.count ?: logItem.chapters.size,
 		manga = logItem.manga,
 		isNew = logItem.isNew,
 	)
@@ -231,7 +231,7 @@ class ContentListMapper @Inject constructor(
 					metadataSelection = metadataSelections[logItem.manga.id],
 					trackingDetailsCache = trackingDetailsCache,
 				),
-				count = logItem.chapters.size,
+				count = logItem.count ?: logItem.chapters.size,
 				manga = logItem.manga,
 				isNew = logItem.isNew,
 			)

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
@@ -1187,8 +1187,6 @@ internal fun FeedTopLevelRouteContent(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.update() },
             onLoadMore = { viewModel.requestMoreItems() },
-            showAllUpdates = showAllUpdates,
-            onShowAllUpdatesChanged = { viewModel.setShowAllUpdates(it) },
             onFeedItemClick = { item, _ ->
                 viewModel.onItemClick(item)
                 val content = item.toContentWithOverride()

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
@@ -1112,6 +1112,7 @@ internal fun FeedTopLevelRouteContent(
     val selectedCategoryId by viewModel.currentCategoryId.collectAsStateWithLifecycle()
     val selectedGroupTab by viewModel.currentGroupTab.collectAsStateWithLifecycle()
     val selectedSourceTags by viewModel.currentSourceTags.collectAsStateWithLifecycle()
+    val showAllUpdates by viewModel.showAllUpdates.collectAsStateWithLifecycle()
     val activity = LocalContext.current as? androidx.activity.ComponentActivity
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
 
@@ -1186,6 +1187,8 @@ internal fun FeedTopLevelRouteContent(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.update() },
             onLoadMore = { viewModel.requestMoreItems() },
+            showAllUpdates = showAllUpdates,
+            onShowAllUpdatesChanged = { viewModel.setShowAllUpdates(it) },
             onFeedItemClick = { item, _ ->
                 viewModel.onItemClick(item)
                 val content = item.toContentWithOverride()

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
@@ -703,6 +703,9 @@ fun KototoroApp(
     val globalFavoritesSortOrder by appSettings.observeAsState(keys = arrayOf(AppSettings.KEY_FAVORITES_ORDER)) {
         allFavoritesSortOrder
     }
+    val showAllUpdates by appSettings.observeAsState(keys = arrayOf(org.skepsun.kototoro.core.prefs.AppSettings.KEY_SHOW_ALL_UPDATES)) {
+        showAllUpdates
+    }
     val sortOrders = layeredTopBarOverrideState?.sortOrders?.takeIf { it.isNotEmpty() } ?: fallbackFavoritesSortOrders
     val selectedSortOrder = layeredTopBarOverrideState?.selectedSortOrder ?: if (isFavoritesRoute) {
         globalFavoritesSortOrder
@@ -928,6 +931,21 @@ fun KototoroApp(
                         sortOrders = sortOrders,
                         selectedSortOrder = selectedSortOrder,
                         onSortOrderSelected = onDisplaySortOrderSelected,
+                        isFeedScreen = chromeTopLevelKey == org.skepsun.kototoro.main.ui.navigation3.FeedNavKey,
+                        showAllUpdates = showAllUpdates,
+                        onShowAllUpdatesChanged = { appSettings.showAllUpdates = it },
+                        onFeedRefresh = {
+                            val workRequest = androidx.work.OneTimeWorkRequestBuilder<org.skepsun.kototoro.tracker.work.TrackWorker>()
+                                .setConstraints(
+                                    androidx.work.Constraints.Builder()
+                                        .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
+                                        .build()
+                                )
+                                .addTag("tracking_oneshot")
+                                .build()
+                            androidx.work.WorkManager.getInstance(context)
+                                .enqueueUniqueWork("tracking_oneshot", androidx.work.ExistingWorkPolicy.REPLACE, workRequest)
+                        },
                     )
                     MainBottomChrome(
                         isLandscapeNavigation = isLandscapeNavigation,
@@ -1219,6 +1237,10 @@ private fun BoxScope.MainTopChrome(
     sortOrders: List<org.skepsun.kototoro.list.domain.ListSortOrder> = emptyList(),
     selectedSortOrder: org.skepsun.kototoro.list.domain.ListSortOrder? = null,
     onSortOrderSelected: (org.skepsun.kototoro.list.domain.ListSortOrder) -> Unit = {},
+    isFeedScreen: Boolean = false,
+    showAllUpdates: Boolean = false,
+    onShowAllUpdatesChanged: (Boolean) -> Unit = {},
+    onFeedRefresh: () -> Unit = {},
 ) {
     val topChromeModifier = Modifier
         .align(if (isLandscapeNavigation) Alignment.TopStart else Alignment.TopCenter)
@@ -1287,6 +1309,10 @@ private fun BoxScope.MainTopChrome(
             sortOrders = sortOrders,
             selectedSortOrder = selectedSortOrder,
             onSortOrderSelected = onSortOrderSelected,
+            isFeedScreen = isFeedScreen,
+            showAllUpdates = showAllUpdates,
+            onShowAllUpdatesChanged = onShowAllUpdatesChanged,
+            onFeedRefresh = onFeedRefresh,
             modifier = topChromeModifier.offset {
                 androidx.compose.ui.unit.IntOffset(0, (effectiveCompactTabsTopBarOffset - effectiveTopBarOffset).toInt())
             },

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroTopBar.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroTopBar.kt
@@ -146,6 +146,10 @@ fun KototoroTopBar(
     sortOrders: List<ListSortOrder> = emptyList(),
     selectedSortOrder: ListSortOrder? = null,
     onSortOrderSelected: (ListSortOrder) -> Unit = {},
+    isFeedScreen: Boolean = false,
+    showAllUpdates: Boolean = false,
+    onShowAllUpdatesChanged: (Boolean) -> Unit = {},
+    onFeedRefresh: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var isMoreMenuExpanded by rememberSaveable { mutableStateOf(false) }
@@ -423,7 +427,7 @@ fun KototoroTopBar(
                     .padding(top = 8.dp),
             )
         }
-        if (showDisplayOptionsSheet && (supportsDisplayModeMenu || supportsGridSizeSlider || onBrowseTrackingRecommendationsChange != null || sortOrders.isNotEmpty())) {
+        if (showDisplayOptionsSheet && (supportsDisplayModeMenu || supportsGridSizeSlider || onBrowseTrackingRecommendationsChange != null || sortOrders.isNotEmpty() || isFeedScreen)) {
             org.skepsun.kototoro.list.ui.compose.DisplayOptionsSheet(
                 supportsDisplayModeMenu = supportsDisplayModeMenu,
                 currentListMode = pendingListMode,
@@ -440,27 +444,55 @@ fun KototoroTopBar(
                 sortOrders = sortOrders,
                 selectedSortOrder = selectedSortOrder,
                 onSortOrderSelected = onSortOrderSelected,
-                extraContent = if (onBrowseTrackingRecommendationsChange != null && isBrowseTrackingRecommendationsEnabled != null) {
+                extraContent = if (isFeedScreen || (onBrowseTrackingRecommendationsChange != null && isBrowseTrackingRecommendationsEnabled != null)) {
                     {
                         Column {
-                            DisplayOptionsSwitchRow(
-                                title = stringResource(R.string.browse_tracking_recommendations),
-                                summary = stringResource(R.string.browse_tracking_recommendations_summary),
-                                checked = isBrowseTrackingRecommendationsEnabled,
-                                onCheckedChange = onBrowseTrackingRecommendationsChange,
-                            )
-                            if (
-                                isBrowseTrackingRecommendationsEnabled &&
-                                isBrowseMoreTrackingRecommendationsEnabled != null &&
-                                onBrowseMoreTrackingRecommendationsChange != null
-                            ) {
-                                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                            if (onBrowseTrackingRecommendationsChange != null && isBrowseTrackingRecommendationsEnabled != null) {
                                 DisplayOptionsSwitchRow(
-                                    title = stringResource(R.string.browse_more_tracking_recommendations),
-                                    summary = stringResource(R.string.browse_more_tracking_recommendations_summary),
-                                    checked = isBrowseMoreTrackingRecommendationsEnabled,
-                                    onCheckedChange = onBrowseMoreTrackingRecommendationsChange,
+                                    title = stringResource(R.string.browse_tracking_recommendations),
+                                    summary = stringResource(R.string.browse_tracking_recommendations_summary),
+                                    checked = isBrowseTrackingRecommendationsEnabled,
+                                    onCheckedChange = onBrowseTrackingRecommendationsChange,
                                 )
+                                if (
+                                    isBrowseTrackingRecommendationsEnabled &&
+                                    isBrowseMoreTrackingRecommendationsEnabled != null &&
+                                    onBrowseMoreTrackingRecommendationsChange != null
+                                ) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                                    DisplayOptionsSwitchRow(
+                                        title = stringResource(R.string.browse_more_tracking_recommendations),
+                                        summary = stringResource(R.string.browse_more_tracking_recommendations_summary),
+                                        checked = isBrowseMoreTrackingRecommendationsEnabled,
+                                        onCheckedChange = onBrowseMoreTrackingRecommendationsChange,
+                                    )
+                                }
+                            }
+                            if (isFeedScreen) {
+                                if (onBrowseTrackingRecommendationsChange != null && isBrowseTrackingRecommendationsEnabled != null) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                                }
+                                Column {
+                                    DisplayOptionsSwitchRow(
+                                        title = stringResource(R.string.show_all_updates),
+                                        summary = stringResource(R.string.feed_behavior_description),
+                                        checked = showAllUpdates,
+                                        onCheckedChange = onShowAllUpdatesChanged,
+                                    )
+                                    androidx.compose.animation.AnimatedVisibility(visible = showAllUpdates) {
+                                        Box(modifier = Modifier.fillMaxWidth()) {
+                                            androidx.compose.material3.TextButton(
+                                                onClick = {
+                                                    onFeedRefresh()
+                                                    showDisplayOptionsSheet = false
+                                                },
+                                                modifier = Modifier.align(Alignment.CenterEnd)
+                                            ) {
+                                                Text(text = stringResource(R.string.trigger_update_now))
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/data/TracksDao.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/data/TracksDao.kt
@@ -60,6 +60,17 @@ abstract class TracksDao : MangaQueryBuilder.ConditionCallback {
 			.build(),
 	)
 
+	fun observeAllTracks(
+		limit: Int,
+		filterOptions: Set<ListFilterOption>,
+	): Flow<List<TrackEntity>> = observeContentImpl(
+		MangaQueryBuilder("tracks", this)
+			.filters(filterOptions)
+			.limit(limit)
+			.orderBy("${pinnedSortExpr("tracks.manga_id")} DESC, last_chapter_date DESC")
+			.build(),
+	)
+
 	@Query("DELETE FROM tracks")
 	abstract suspend fun clear()
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
@@ -116,6 +116,15 @@ class TrackingRepository @Inject constructor(
 			.onStart { gcIfNotCalled() }
 	}
 
+	fun observeAllTracks(limit: Int, filterOptions: Set<ListFilterOption>): Flow<List<ContentTracking>> {
+		return db.getTracksDao().observeAllTracks(limit, filterOptions)
+			.mapLatest { tracks ->
+				workAggregateRepository.buildTrackingAggregates(tracks)
+					.mapNotNull { aggregate -> aggregate.toContentTracking() }
+			}.distinctUntilChanged()
+			.onStart { gcIfNotCalled() }
+	}
+
 	suspend fun getTracks(offset: Int, limit: Int): List<ContentTracking> {
 		return workAggregateRepository
 			.buildTrackingAggregates(db.getTracksDao().findAll(offset = offset, limit = limit))

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/model/TrackingLogItem.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/model/TrackingLogItem.kt
@@ -12,4 +12,5 @@ data class TrackingLogItem(
 	val chapters: List<String>,
 	val createdAt: Instant,
 	val isNew: Boolean,
+	val count: Int? = null,
 )

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
@@ -13,8 +13,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import org.skepsun.kototoro.core.db.MangaDatabase
 import kotlinx.coroutines.plus
 import org.skepsun.kototoro.R
 import org.skepsun.kototoro.core.jsonsource.SourceGroupManager
@@ -50,6 +52,12 @@ import org.skepsun.kototoro.tracker.ui.feed.model.FeedItem
 import org.skepsun.kototoro.tracker.ui.feed.model.UpdatedContentHeader
 import org.skepsun.kototoro.tracker.ui.feed.model.UpdatedContentHeaderItem
 import org.skepsun.kototoro.tracker.work.TrackWorker
+import org.skepsun.kototoro.core.prefs.TriStateOption
+import org.skepsun.kototoro.download.ui.worker.DownloadTask
+import org.skepsun.kototoro.download.ui.worker.DownloadWorker
+import org.skepsun.kototoro.download.ui.worker.ExecutionChapterRef
+import org.skepsun.kototoro.history.data.HistoryRepository
+import org.skepsun.kototoro.local.data.LocalMangaRepository
 import org.skepsun.kototoro.parsers.model.Content
 import org.skepsun.kototoro.core.parser.ContentDataRepository
 import org.skepsun.kototoro.work.domain.WorkResolver
@@ -112,14 +120,101 @@ class FeedViewModel @Inject constructor(
 		valueProducer = { isFeedHeaderVisible },
 	)
 
+	sealed class DownloadPrompt {
+		data class MultipleUpdates(
+			val manga: Content,
+			val lastChapterId: Long,
+			val allNewChaptersIds: LongArray,
+		) : DownloadPrompt() {
+			override fun equals(other: Any?): Boolean {
+				if (this === other) return true
+				if (other !is MultipleUpdates) return false
+				if (manga != other.manga) return false
+				if (lastChapterId != other.lastChapterId) return false
+				return allNewChaptersIds contentEquals other.allNewChaptersIds
+			}
+
+			override fun hashCode(): Int {
+				var result = manga.hashCode()
+				result = 31 * result + lastChapterId.hashCode()
+				result = 31 * result + allNewChaptersIds.contentHashCode()
+				return result
+			}
+		}
+
+		data class NoReadHistory(
+			val manga: Content,
+			val lastChapterId: Long,
+			val allChaptersIds: LongArray,
+		) : DownloadPrompt() {
+			override fun equals(other: Any?): Boolean {
+				if (this === other) return true
+				if (other !is NoReadHistory) return false
+				if (manga != other.manga) return false
+				if (lastChapterId != other.lastChapterId) return false
+				return allChaptersIds contentEquals other.allChaptersIds
+			}
+
+			override fun hashCode(): Int {
+				var result = manga.hashCode()
+				result = 31 * result + lastChapterId.hashCode()
+				result = 31 * result + allChaptersIds.contentHashCode()
+				return result
+			}
+		}
+	}
+
+	data class DeleteChapterPrompt(
+		val manga: Content,
+		val chapterId: Long,
+		val chapterTitle: String,
+	)
+
+	val showAllUpdates = settings.observeAsStateFlow(
+		scope = viewModelScope + Dispatchers.Default,
+		key = AppSettings.KEY_SHOW_ALL_UPDATES,
+		valueProducer = { showAllUpdates },
+	)
+
+	private val logFlow = showAllUpdates.flatMapLatest { showAll ->
+		val combinedSettings = quickFilter.appliedOptions.combineWithSettings()
+		if (showAll) {
+			combine(limit, combinedSettings, ::Pair)
+				.flatMapLatest { repository.observeAllTracks(it.first, it.second) }
+				.mapLatest { tracks ->
+					if (tracks.isEmpty()) return@mapLatest emptyList<TrackingLogItem>()
+					val mangaIds = tracks.map { it.manga.id }
+					val allChapters = db.getChaptersDao().findAllByMangaIds(mangaIds)
+					val chaptersByMangaId = allChapters.groupBy { it.mangaId }
+					tracks.map { track ->
+						val chapters = chaptersByMangaId[track.manga.id].orEmpty()
+							.takeLast(10)
+							.reversed()
+							.map { it.title }
+						TrackingLogItem(
+							id = -track.manga.id,
+							anchorMangaId = track.manga.id,
+							entityId = track.entityId,
+							preferredLocalMangaId = track.preferredLocalMangaId,
+							manga = track.manga,
+							chapters = chapters,
+							createdAt = track.lastChapterDate ?: track.lastCheck ?: java.time.Instant.EPOCH,
+							isNew = track.newChapters > 0,
+						)
+					}
+				}
+		} else {
+			combine(limit, combinedSettings, ::Pair)
+				.flatMapLatest { repository.observeTrackingLog(it.first, it.second) }
+		}
+	}
 	val onActionDone = MutableEventFlow<ReversibleAction>()
 
 	@Suppress("USELESS_CAST")
 	val content = combine(
 		observeHeader(),
 		quickFilter.appliedOptions,
-		combine(limit, quickFilter.appliedOptions.combineWithSettings(), ::Pair)
-			.flatMapLatest { repository.observeTrackingLog(it.first, it.second) },
+		logFlow,
 		quickFilter.appliedOptions.combineWithSettings()
 			.flatMapLatest { repository.observeUpdatedContent(UPDATED_CONTENT_LOOKAHEAD_SIZE, it) },
 		selectedCategoryId,
@@ -238,6 +333,10 @@ class FeedViewModel @Inject constructor(
 
 	fun setHeaderEnabled(value: Boolean) {
 		settings.isFeedHeaderVisible = value
+	}
+
+	fun setShowAllUpdates(value: Boolean) {
+		settings.showAllUpdates = value
 	}
 
 	fun onItemClick(item: FeedItem) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
@@ -201,6 +201,7 @@ class FeedViewModel @Inject constructor(
 							chapters = chapters,
 							createdAt = track.lastChapterDate ?: track.lastCheck ?: java.time.Instant.EPOCH,
 							isNew = track.newChapters > 0,
+							count = track.newChapters,
 						)
 					}
 				}
@@ -295,6 +296,7 @@ class FeedViewModel @Inject constructor(
 			chapters = List(newChapters.coerceAtLeast(1)) { "" },
 			createdAt = lastChapterDate ?: lastCheck ?: java.time.Instant.EPOCH,
 			isNew = newChapters > 0,
+			count = newChapters,
 		)
 	}
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
@@ -80,6 +80,7 @@ class FeedViewModel @Inject constructor(
 	private val sourcePresetsRepository: org.skepsun.kototoro.explore.data.SourcePresetsRepository,
 	private val dataRepository: ContentDataRepository,
 	private val workResolver: WorkResolver,
+	private val db: MangaDatabase,
 ) : BaseViewModel(), QuickFilterListener by quickFilter {
 
 	private data class HeaderParams(

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -73,6 +74,8 @@ fun FeedScreen(
 	onCategorySelected: (Long) -> Unit,
 	onQuickFilterOptionClick: (ListFilterOption) -> Unit,
 	showCategoryFilterInline: Boolean = true,
+	showAllUpdates: Boolean = false,
+	onShowAllUpdatesChanged: (Boolean) -> Unit = {},
 	modifier: Modifier = Modifier
 ) {
 	val listState = rememberSaveable(saver = LazyListState.Saver) {
@@ -162,6 +165,13 @@ fun FeedScreen(
 			),
 			modifier = Modifier.fillMaxSize()
 		) {
+			item(key = "show_all_updates_header") {
+				ShowAllUpdatesHeader(
+					showAllUpdates = showAllUpdates,
+					onShowAllUpdatesChanged = onShowAllUpdatesChanged,
+					onTriggerRefresh = onRefresh
+				)
+			}
 			itemsIndexed(
 				items = items,
 				key = { index, item ->
@@ -279,6 +289,67 @@ private fun FeedEmptyState(
 				style = MaterialTheme.typography.bodyMedium,
 				color = MaterialTheme.colorScheme.onSurfaceVariant,
 			)
+		}
+	}
+}
+
+@Composable
+private fun ShowAllUpdatesHeader(
+	showAllUpdates: Boolean,
+	onShowAllUpdatesChanged: (Boolean) -> Unit,
+	onTriggerRefresh: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Column(
+		modifier = modifier
+			.fillMaxWidth()
+			.padding(horizontal = 16.dp, vertical = 8.dp)
+	) {
+		Row(
+			verticalAlignment = Alignment.CenterVertically,
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(vertical = 4.dp)
+		) {
+			Text(
+				text = stringResource(R.string.show_all_updates),
+				style = MaterialTheme.typography.titleMedium,
+				color = MaterialTheme.colorScheme.onBackground,
+				modifier = Modifier.weight(1f)
+			)
+			androidx.compose.material3.Switch(
+				checked = showAllUpdates,
+				onCheckedChange = onShowAllUpdatesChanged
+			)
+		}
+		
+		androidx.compose.animation.AnimatedVisibility(visible = showAllUpdates) {
+			androidx.compose.material3.ElevatedCard(
+				colors = androidx.compose.material3.CardDefaults.elevatedCardColors(
+					containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+				),
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(top = 8.dp)
+			) {
+				Column(
+					modifier = Modifier
+						.padding(16.dp)
+				) {
+					Text(
+						text = stringResource(R.string.feed_behavior_description),
+						style = MaterialTheme.typography.bodyMedium,
+						color = MaterialTheme.colorScheme.onSurfaceVariant
+					)
+					Spacer(modifier = Modifier.height(12.dp))
+					androidx.compose.material3.TextButton(
+						onClick = onTriggerRefresh,
+						modifier = Modifier.align(Alignment.End)
+					) {
+						Text(text = stringResource(R.string.trigger_update_now))
+					}
+				}
+			}
 		}
 	}
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
@@ -74,8 +74,6 @@ fun FeedScreen(
 	onCategorySelected: (Long) -> Unit,
 	onQuickFilterOptionClick: (ListFilterOption) -> Unit,
 	showCategoryFilterInline: Boolean = true,
-	showAllUpdates: Boolean = false,
-	onShowAllUpdatesChanged: (Boolean) -> Unit = {},
 	modifier: Modifier = Modifier
 ) {
 	val listState = rememberSaveable(saver = LazyListState.Saver) {
@@ -165,13 +163,7 @@ fun FeedScreen(
 			),
 			modifier = Modifier.fillMaxSize()
 		) {
-			item(key = "show_all_updates_header") {
-				ShowAllUpdatesHeader(
-					showAllUpdates = showAllUpdates,
-					onShowAllUpdatesChanged = onShowAllUpdatesChanged,
-					onTriggerRefresh = onRefresh
-				)
-			}
+
 			itemsIndexed(
 				items = items,
 				key = { index, item ->
@@ -293,63 +285,4 @@ private fun FeedEmptyState(
 	}
 }
 
-@Composable
-private fun ShowAllUpdatesHeader(
-	showAllUpdates: Boolean,
-	onShowAllUpdatesChanged: (Boolean) -> Unit,
-	onTriggerRefresh: () -> Unit,
-	modifier: Modifier = Modifier,
-) {
-	Column(
-		modifier = modifier
-			.fillMaxWidth()
-			.padding(horizontal = 16.dp, vertical = 8.dp)
-	) {
-		Row(
-			verticalAlignment = Alignment.CenterVertically,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(vertical = 4.dp)
-		) {
-			Text(
-				text = stringResource(R.string.show_all_updates),
-				style = MaterialTheme.typography.titleMedium,
-				color = MaterialTheme.colorScheme.onBackground,
-				modifier = Modifier.weight(1f)
-			)
-			androidx.compose.material3.Switch(
-				checked = showAllUpdates,
-				onCheckedChange = onShowAllUpdatesChanged
-			)
-		}
-		
-		androidx.compose.animation.AnimatedVisibility(visible = showAllUpdates) {
-			androidx.compose.material3.ElevatedCard(
-				colors = androidx.compose.material3.CardDefaults.elevatedCardColors(
-					containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-				),
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(top = 8.dp)
-			) {
-				Column(
-					modifier = Modifier
-						.padding(16.dp)
-				) {
-					Text(
-						text = stringResource(R.string.feed_behavior_description),
-						style = MaterialTheme.typography.bodyMedium,
-						color = MaterialTheme.colorScheme.onSurfaceVariant
-					)
-					Spacer(modifier = Modifier.height(12.dp))
-					androidx.compose.material3.TextButton(
-						onClick = onTriggerRefresh,
-						modifier = Modifier.align(Alignment.End)
-					) {
-						Text(text = stringResource(R.string.trigger_update_now))
-					}
-				}
-			}
-		}
-	}
-}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,9 @@
     <string name="size_s">Size: %s</string>
     <string name="clear_updates_feed">Clear updates feed</string>
     <string name="updates_feed_cleared">Cleared</string>
+    <string name="show_all_updates">Show all updates</string>
+    <string name="feed_behavior_description">Default: The feed only shows new, unread chapters checked since your last visit.\n\nActive: Displays all cached chapters (up to 10 per item) regardless of reading status, organized by fetch date. Trigger a full update to fetch the latest chapters.</string>
+    <string name="trigger_update_now">Trigger Update</string>
     <string name="rotate_screen">Rotate screen</string>
     <string name="update">Update</string>
     <string name="feed_will_update_soon">Feed update will start soon</string>


### PR DESCRIPTION
This pull request introduces a new "Show All Updates" feature to the feed screen, allowing users to toggle between viewing only recent updates or all tracked content. The implementation includes UI changes to expose this option in the top bar, new settings and state handling, and backend support for efficiently loading all tracked items. Additionally, several code improvements and refactorings were made to support this feature.

**New "Show All Updates" Feature:**

- Added a new `showAllUpdates` boolean preference to `AppSettings`, including key definition and getter/setter methods. [[1]](diffhunk://#diff-251b1b693f6b74338a48bbf52ebd6b1a13b7f1af03c955f965aa2f1262d662feR798-R801) [[2]](diffhunk://#diff-251b1b693f6b74338a48bbf52ebd6b1a13b7f1af03c955f965aa2f1262d662feR2308)
- Exposed the `showAllUpdates` setting in the UI: passed through `KototoroApp`, `MainTopChrome`, and `KototoroTopBar`, and added a toggle switch and refresh button to the feed's display options sheet. [[1]](diffhunk://#diff-57b3c9c2765cc6dca72fd70ba0eb4a4626bf86ed2bd6f28e92953b90f548143fR706-R708) [[2]](diffhunk://#diff-57b3c9c2765cc6dca72fd70ba0eb4a4626bf86ed2bd6f28e92953b90f548143fR934-R948) [[3]](diffhunk://#diff-57b3c9c2765cc6dca72fd70ba0eb4a4626bf86ed2bd6f28e92953b90f548143fR1240-R1243) [[4]](diffhunk://#diff-57b3c9c2765cc6dca72fd70ba0eb4a4626bf86ed2bd6f28e92953b90f548143fR1312-R1315) [[5]](diffhunk://#diff-086697fbf089dd228d5d9cc1215b185e36cd59f7c7766cab2d5ddd4acf262157R149-R152) [[6]](diffhunk://#diff-086697fbf089dd228d5d9cc1215b185e36cd59f7c7766cab2d5ddd4acf262157L426-R430) [[7]](diffhunk://#diff-086697fbf089dd228d5d9cc1215b185e36cd59f7c7766cab2d5ddd4acf262157L443-R450) [[8]](diffhunk://#diff-086697fbf089dd228d5d9cc1215b185e36cd59f7c7766cab2d5ddd4acf262157R471-R497)
- Updated `FeedViewModel` to observe the `showAllUpdates` setting, and to provide a combined flow (`logFlow`) that loads either all tracked items or just recent updates, depending on the setting. [[1]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R124-R219) [[2]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R299) [[3]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R341-R344)

**Backend and Data Layer Enhancements:**

- Added `observeAllTracks` to `TracksDao` and `TrackingRepository` to support efficient loading of all tracked manga for the feed. [[1]](diffhunk://#diff-ebebb28d675dc0a1e9bcf9f5cb47b4a1af72c863e8f2f2edb5dc29a488180516R63-R73) [[2]](diffhunk://#diff-59d4b7e3ec5145f3cace86e9797e6e0d6cb963e169f4e6fa0d14afebf443825dR119-R127)
- Updated the `TrackingLogItem` model and mapping logic to support an optional `count` field, used for displaying the number of new chapters. [[1]](diffhunk://#diff-16de9c2db1be5aec108de67228f2cd5f3c46ecd49cf2abfa7eb4d3f955d120b5R15) [[2]](diffhunk://#diff-9c314912d8675ea71e13ff8fe9284694fe9ea172b14e30472f347277bc623c47L210-R210) [[3]](diffhunk://#diff-9c314912d8675ea71e13ff8fe9284694fe9ea172b14e30472f347277bc623c47L234-R234)

**Code Quality and Refactoring:**

- Added new imports and dependency injections to support the new logic and database access in `FeedViewModel`. [[1]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R16-R19) [[2]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R55-R60) [[3]](diffhunk://#diff-5e03432c38952e6ffd6265bac487d13e666952649ccf03c9d945ca384fc41b29R83)
- Minor UI improvements, such as including `Row` import for future layout needs.

These changes together provide users with more control over the feed's behavior and lay the groundwork for further enhancements to content tracking and discovery.