### PR TITLE
Futureproofing for the new Tachiyomix 1.6 standard. Implemented a fallback method for legacy extensions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ docs/.vitepress/dist/
 policy
 chroma
 reasonix.toml
+/.vscode

--- a/app/src/main/kotlin/eu/kanade/tachiyomi/source/model/SChapter.kt
+++ b/app/src/main/kotlin/eu/kanade/tachiyomi/source/model/SChapter.kt
@@ -3,6 +3,7 @@
 package eu.kanade.tachiyomi.source.model
 
 import java.io.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Mihon-compatible SChapter interface.
@@ -20,12 +21,46 @@ interface SChapter : Serializable {
 
     var scanlator: String?
 
+    // TachiyomiX 1.6+ additions with default implementations for backward compatibility
+    var number: String?
+        get() = if (chapter_number >= 0) chapter_number.toString() else null
+        set(value) {
+            chapter_number = value?.toFloatOrNull() ?: -1f
+        }
+
+    var volume: String?
+        get() = null
+        set(value) {}
+
+    var scanlators: List<String>
+        get() = scanlator?.let { listOf(it) } ?: emptyList()
+        set(value) {
+            scanlator = value.joinToString(", ")
+        }
+
+    var note: String?
+        get() = null
+        set(value) {}
+
+    var memo: JsonObject
+        get() = JsonObject(emptyMap())
+        set(value) {}
+
     fun copyFrom(other: SChapter) {
         name = other.name
         url = other.url
         date_upload = other.date_upload
         chapter_number = other.chapter_number
         scanlator = other.scanlator
+        try {
+            number = other.number
+            volume = other.volume
+            scanlators = other.scanlators
+            note = other.note
+            memo = other.memo
+        } catch (e: NoSuchMethodError) {
+            // Fallback for compatibility
+        }
     }
 
     companion object {
@@ -49,4 +84,46 @@ class SChapterImpl : SChapter {
     override var chapter_number: Float = -1f
 
     override var scanlator: String? = null
+
+    // Overridden fields in default implementation to back the new properties
+    private var _number: String? = null
+    override var number: String?
+        get() {
+            val local = _number
+            if (local != null) return local
+            return if (chapter_number >= 0) chapter_number.toString() else null
+        }
+        set(value) {
+            _number = value
+            val parsed = value?.toFloatOrNullCompat()
+            if (parsed != null) {
+                chapter_number = parsed
+            }
+        }
+
+    override var volume: String? = null
+
+    private var _scanlators: List<String>? = null
+    override var scanlators: List<String>
+        get() {
+            val local = _scanlators
+            if (local != null) return local
+            return scanlator?.let { listOf(it) } ?: emptyList()
+        }
+        set(value) {
+            _scanlators = value
+            scanlator = value.joinToString(", ")
+        }
+
+    override var note: String? = null
+    override var memo: JsonObject = JsonObject(emptyMap())
+}
+
+/**
+ * Compatible helper function to parse float from string chapter number (e.g. "10.5a" -> 10.5f).
+ */
+fun String.toFloatOrNullCompat(): Float? {
+    this.toFloatOrNull()?.let { return it }
+    val clean = this.trim().replace(Regex("[a-zA-Z]+$"), "")
+    return clean.toFloatOrNull()
 }

--- a/app/src/main/kotlin/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/kotlin/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -3,6 +3,7 @@
 package eu.kanade.tachiyomi.source.model
 
 import java.io.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Mihon-compatible SManga interface.
@@ -30,10 +31,40 @@ interface SManga : Serializable {
 
     var initialized: Boolean
 
-    fun getGenres(): List<String>? {
-        if (genre.isNullOrBlank()) return null
-        return genre?.split(", ")?.map { it.trim() }?.filterNot { it.isBlank() }?.distinct()
-    }
+    // TachiyomiX 1.6+ additions with default implementations for backward compatibility
+    var genres: List<String>
+        get() {
+            val g = try { genre } catch (e: Exception) { null }
+            if (g.isNullOrBlank()) return emptyList()
+            return g.split(", ").map { it.trim() }.filterNot { it.isBlank() }.distinct()
+        }
+        set(value) {
+            genre = value.joinToString(", ")
+        }
+
+    var altTitles: List<String>
+        get() = emptyList()
+        set(value) {}
+
+    var banner: String?
+        get() = null
+        set(value) {}
+
+    var contentRating: ContentRating
+        get() = ContentRating.SAFE
+        set(value) {}
+
+    var score: Int?
+        get() = null
+        set(value) {}
+
+    var readingMode: ReadingMode?
+        get() = null
+        set(value) {}
+
+    var memo: JsonObject
+        get() = JsonObject(emptyMap())
+        set(value) {}
 
     fun copy() = create().also {
         it.url = url
@@ -46,7 +77,21 @@ interface SManga : Serializable {
         it.thumbnail_url = thumbnail_url
         it.update_strategy = update_strategy
         it.initialized = initialized
+        try {
+            it.genres = genres
+            it.altTitles = altTitles
+            it.banner = banner
+            it.contentRating = contentRating
+            it.score = score
+            it.readingMode = readingMode
+            it.memo = memo
+        } catch (e: NoSuchMethodError) {
+            // Fallback for bytecode/compatibility issues
+        }
     }
+
+    enum class ContentRating { SAFE, SUGGESTIVE, ADULT }
+    enum class ReadingMode { RIGHT_TO_LEFT, LEFT_TO_RIGHT, LONG_STRIP }
 
     companion object {
         const val UNKNOWN = 0
@@ -87,4 +132,26 @@ class SMangaImpl : SManga {
     override var update_strategy: UpdateStrategy = UpdateStrategy.ALWAYS_UPDATE
 
     override var initialized: Boolean = false
+
+    // Overridden fields in default implementation to back the new properties
+    private var _genres: List<String>? = null
+    override var genres: List<String>
+        get() {
+            val local = _genres
+            if (local != null) return local
+            val g = try { genre } catch (e: Exception) { null }
+            if (g.isNullOrBlank()) return emptyList()
+            return g.split(", ").map { it.trim() }.filterNot { it.isBlank() }.distinct()
+        }
+        set(value) {
+            _genres = value
+            genre = value.joinToString(", ")
+        }
+
+    override var altTitles: List<String> = emptyList()
+    override var banner: String? = null
+    override var contentRating: SManga.ContentRating = SManga.ContentRating.SAFE
+    override var score: Int? = null
+    override var readingMode: SManga.ReadingMode? = null
+    override var memo: JsonObject = JsonObject(emptyMap())
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/extensions/runtime/ExternalExtensionMetadataSupport.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/extensions/runtime/ExternalExtensionMetadataSupport.kt
@@ -8,6 +8,8 @@ object ExternalExtensionMetadataSupport {
 	data class DeclaredSourceMetadata(
 		val sourceClassName: String,
 		val isNsfw: Boolean,
+		val contentWarning: Int? = null,
+		val libVersionOverride: Double? = null,
 	)
 
 	fun getMetaDataOrNull(appInfo: ApplicationInfo?): Bundle? = appInfo?.metaData
@@ -39,15 +41,47 @@ object ExternalExtensionMetadataSupport {
 		sourceClassKey: String,
 		sourceFactoryKey: String,
 		nsfwKey: String,
+		contentWarningKey: String = "tachiyomix.contentWarning",
+		libVersionKey: String = "tachiyomix.extensionLib",
 	): DeclaredSourceMetadata? {
 		val sourceClassName = getSourceClassNameOrNull(
 			metaData = metaData,
 			sourceClassKey = sourceClassKey,
 			sourceFactoryKey = sourceFactoryKey,
 		) ?: return null
+		
+		val contentWarningVal = if (metaData.containsKey(contentWarningKey)) {
+			metaData.getInt(contentWarningKey)
+		} else {
+			null
+		}
+		
+		val isNsfw = if (contentWarningVal != null) {
+			contentWarningVal == 2
+		} else {
+			metaData.getInt(nsfwKey, 0) == 1
+		}
+		
+		val libVersionOverride = if (metaData.containsKey(libVersionKey)) {
+			try {
+				val rawVal = metaData.get(libVersionKey)
+				when (rawVal) {
+					is Number -> rawVal.toDouble()
+					is String -> rawVal.toDoubleOrNull()
+					else -> null
+				}
+			} catch (e: Exception) {
+				null
+			}
+		} else {
+			null
+		}
+		
 		return DeclaredSourceMetadata(
 			sourceClassName = sourceClassName,
-			isNsfw = isNsfw(metaData, nsfwKey),
+			isNsfw = isNsfw,
+			contentWarning = contentWarningVal,
+			libVersionOverride = libVersionOverride,
 		)
 	}
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/mihon/MihonExtensionLoader.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/mihon/MihonExtensionLoader.kt
@@ -48,6 +48,9 @@ class MihonExtensionLoader @Inject constructor(
         private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"
         private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
         
+        // TachiyomiX additions
+        private const val METADATA_NEW_NAME = "tachiyomix.name"
+        
         // Supported library version range
         const val LIB_VERSION_MIN = 1.2
         const val LIB_VERSION_MAX = 1.9
@@ -181,17 +184,6 @@ class MihonExtensionLoader @Inject constructor(
             return null
         }
         
-        // Extract library version - handles different version formats
-        val libVersion = try {
-            versionName.split('.').let { parts ->
-                if (parts.size >= 2) "${parts[0]}.${parts[1]}".toDouble()
-                else parts[0].toDouble()
-            }
-        } catch (e: Exception) {
-            android.util.Log.w(TAG, "extractExtensionInfo($pkgName): Failed to parse libVersion from $versionName, defaulting to 1.4")
-            1.4 // Default to 1.4 if parsing fails
-        }
-        
         val declaredSource = ExternalExtensionMetadataSupport.getDeclaredSourceMetadataOrNull(
             metaData = metaData,
             sourceClassKey = METADATA_SOURCE_CLASS,
@@ -202,8 +194,19 @@ class MihonExtensionLoader @Inject constructor(
             return null
         }
         
+        // Extract library version - handles different version formats
+        val libVersion = declaredSource.libVersionOverride ?: try {
+            versionName.split('.').let { parts ->
+                if (parts.size >= 2) "${parts[0]}.${parts[1]}".toDouble()
+                else parts[0].toDouble()
+            }
+        } catch (e: Exception) {
+            android.util.Log.w(TAG, "extractExtensionInfo($pkgName): Failed to parse libVersion from $versionName, defaulting to 1.4")
+            1.4 // Default to 1.4 if parsing fails
+        }
+        
         // Get app name safely
-        val appName = try {
+        val appName = metaData.getString(METADATA_NEW_NAME) ?: try {
             ExternalExtensionLoaderSupport.getAppLabel(applicationContext, appInfo)
         } catch (e: Exception) {
             null
@@ -243,25 +246,6 @@ class MihonExtensionLoader @Inject constructor(
             }
         val versionCode = PackageInfoCompat.getLongVersionCode(completePkgInfo)
         
-        // Extract library version - match Mihon's logic (substringBeforeLast)
-        val libVersion = versionName.substringBeforeLast('.').toDoubleOrNull()
-            ?: try {
-                versionName.split('.').let { parts ->
-                    if (parts.size >= 2) "${parts[0]}.${parts[1]}".toDouble()
-                    else parts[0].toDouble()
-                }
-            } catch (e: Exception) {
-                android.util.Log.e(TAG, "loadExtension($pkgName) FAILED: Invalid lib version format ($versionName)")
-                return MihonLoadResult.Error(pkgName, "Invalid lib version format: $versionName")
-            }
-        
-        // Check library version compatibility
-        if (libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
-            val err = "Incompatible lib version: $libVersion (supported: $LIB_VERSION_MIN-$LIB_VERSION_MAX) for versionName=$versionName"
-            android.util.Log.e(TAG, "loadExtension($pkgName) FAILED: $err")
-            return MihonLoadResult.Error(pkgName, err)
-        }
-        
         val metaData = ExternalExtensionMetadataSupport.getMetaDataOrNull(appInfo)
             ?: run {
                 android.util.Log.e(TAG, "loadExtension($pkgName) FAILED: No meta-data in manifest")
@@ -279,8 +263,27 @@ class MihonExtensionLoader @Inject constructor(
             return MihonLoadResult.Error(pkgName, "No source class specified in manifest")
         }
         
+        // Extract library version - match Mihon's logic (substringBeforeLast)
+        val libVersion = declaredSource.libVersionOverride ?: versionName.substringBeforeLast('.').toDoubleOrNull()
+            ?: try {
+                versionName.split('.').let { parts ->
+                    if (parts.size >= 2) "${parts[0]}.${parts[1]}".toDouble()
+                    else parts[0].toDouble()
+                }
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "loadExtension($pkgName) FAILED: Invalid lib version format ($versionName)")
+                return MihonLoadResult.Error(pkgName, "Invalid lib version format: $versionName")
+            }
+        
+        // Check library version compatibility
+        if (libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
+            val err = "Incompatible lib version: $libVersion (supported: $LIB_VERSION_MIN-$LIB_VERSION_MAX) for versionName=$versionName"
+            android.util.Log.e(TAG, "loadExtension($pkgName) FAILED: $err")
+            return MihonLoadResult.Error(pkgName, err)
+        }
+        
         // Get app name and language
-        val appName = ExternalExtensionLoaderSupport.getAppLabel(context, appInfo)
+        val appName = metaData.getString(METADATA_NEW_NAME) ?: ExternalExtensionLoaderSupport.getAppLabel(context, appInfo)
         val lang = ExternalExtensionLoaderSupport.extractLanguage(pkgName, "extension")
         
         // Create ClassLoader for this extension

--- a/app/src/main/kotlin/org/skepsun/kototoro/mihon/model/MihonDataConverters.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/mihon/model/MihonDataConverters.kt
@@ -3,6 +3,7 @@ package org.skepsun.kototoro.mihon.model
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.toFloatOrNullCompat
 import eu.kanade.tachiyomi.source.online.HttpSource
 import org.skepsun.kototoro.core.model.isAdultTagKeyword
 import org.skepsun.kototoro.parsers.model.ContentRating
@@ -40,37 +41,88 @@ fun SManga.toKotoContent(
     
     // Safely access lateinit properties
     val safeTitle = try { title } catch (e: UninitializedPropertyAccessException) { "Unknown" }
-    val safeGenres = try { getGenres() } catch (e: UninitializedPropertyAccessException) { null }
+    
+    // Try accessing genres property, which falls back to legacy genre property internally
+    val safeGenres = try {
+        genres
+    } catch (e: Exception) {
+        null
+    }
+    
     val safeAuthor = try { author } catch (e: UninitializedPropertyAccessException) { null }
     val safeArtist = try { artist } catch (e: UninitializedPropertyAccessException) { null }
     val safeDescription = try { description } catch (e: UninitializedPropertyAccessException) { null }
     val safeStatus = try { status } catch (e: UninitializedPropertyAccessException) { SManga.UNKNOWN }
+    
+    // Try accessing altTitles
+    val safeAltTitles = try {
+        altTitles.toSet()
+    } catch (e: NoSuchMethodError) {
+        emptySet()
+    }
+    
+    // Try accessing banner cover
+    val safeBanner = try {
+        banner?.let { resolveUrl(baseUrl, it) }
+    } catch (e: NoSuchMethodError) {
+        null
+    }
+    
+    // Parse rating from score
+    val calculatedRating = try {
+        val safeScore = score
+        if (safeScore != null && safeScore > 0) {
+            if (safeScore <= 10) safeScore / 10f
+            else if (safeScore <= 100) safeScore / 100f
+            else RATING_UNKNOWN
+        } else {
+            RATING_UNKNOWN
+        }
+    } catch (e: NoSuchMethodError) {
+        RATING_UNKNOWN
+    }
     
     val generatedId = generateContentId(stableUrl, source.name, safeTitle)
 
     return Content(
         id = generatedId,
         title = safeTitle,
-        altTitles = emptySet(),
+        altTitles = safeAltTitles,
         url = stableUrl,
         publicUrl = if (publicUrl.isNotBlank()) publicUrl else absolutePublicUrl,
-        rating = RATING_UNKNOWN,
+        rating = calculatedRating,
         contentRating = run {
-            val safeTags = setOf("safe", "all ages", "non-h", "sfw", "非h", "正常向", "全年龄", "全年龄向")
-            val isExplicitlySafe = safeGenres?.any { it.lowercase() in safeTags } == true
-            
-            val isContentNsfw = (!isExplicitlySafe && source.isNsfw) || safeGenres?.any { it.isAdultTagKeyword() } == true
-            
-            if (isExplicitlySafe) {
-                ContentRating.SAFE
-            } else if (isContentNsfw) {
-                ContentRating.ADULT
-            } else {
+            val explicitRating = try {
+                when (contentRating) {
+                    SManga.ContentRating.SAFE -> ContentRating.SAFE
+                    SManga.ContentRating.SUGGESTIVE -> ContentRating.SUGGESTIVE
+                    SManga.ContentRating.ADULT -> ContentRating.ADULT
+                    else -> null
+                }
+            } catch (e: NoSuchMethodError) {
                 null
+            }
+            
+            if (source.isNsfw) {
+                ContentRating.ADULT
+            } else if (explicitRating != null) {
+                explicitRating
+            } else {
+                val safeTags = setOf("safe", "all ages", "non-h", "sfw", "非h", "正常向", "全年龄", "全年龄向")
+                val isExplicitlySafe = safeGenres?.any { it.lowercase() in safeTags } == true
+                val isContentNsfw = (!isExplicitlySafe && source.isNsfw) || safeGenres?.any { it.isAdultTagKeyword() } == true
+                
+                if (isExplicitlySafe) {
+                    ContentRating.SAFE
+                } else if (isContentNsfw) {
+                    ContentRating.ADULT
+                } else {
+                    null
+                }
             }
         },
         coverUrl = absoluteThumbnailUrl,
-        largeCoverUrl = absoluteThumbnailUrl, // Also set largeCoverUrl for details page
+        largeCoverUrl = safeBanner ?: absoluteThumbnailUrl,
         tags = safeGenres?.mapNotNull { genreName: String ->
             val clean = genreName.cleanMihonGenre()
             if (clean.isEmpty()) null
@@ -85,7 +137,7 @@ fun SManga.toKotoContent(
             SManga.COMPLETED -> ContentState.FINISHED
             SManga.ON_HIATUS -> ContentState.PAUSED
             SManga.CANCELLED -> ContentState.ABANDONED
-            SManga.LICENSED -> ContentState.RESTRICTED  // Map LICENSED to RESTRICTED
+            SManga.LICENSED -> ContentState.RESTRICTED
             SManga.PUBLISHING_FINISHED -> ContentState.FINISHED
             else -> null
         },
@@ -158,11 +210,24 @@ fun Content.toMihonManga(): SManga {
             ContentState.FINISHED -> SManga.COMPLETED
             ContentState.PAUSED -> SManga.ON_HIATUS
             ContentState.ABANDONED -> SManga.CANCELLED
-            ContentState.RESTRICTED -> SManga.LICENSED  // Map RESTRICTED to LICENSED
+            ContentState.RESTRICTED -> SManga.LICENSED
             else -> SManga.UNKNOWN
         }
         this.thumbnail_url = this@toMihonManga.coverUrl
         this.initialized = true
+        try {
+            this.genres = this@toMihonManga.tags.map { it.title }
+            this.altTitles = this@toMihonManga.altTitles.toList()
+            this.banner = this@toMihonManga.largeCoverUrl
+            this.contentRating = when (this@toMihonManga.contentRating) {
+                ContentRating.SAFE -> SManga.ContentRating.SAFE
+                ContentRating.SUGGESTIVE -> SManga.ContentRating.SUGGESTIVE
+                ContentRating.ADULT -> SManga.ContentRating.ADULT
+                else -> SManga.ContentRating.SAFE
+            }
+        } catch (e: NoSuchMethodError) {
+            // Fallback
+        }
     }
 }
 
@@ -173,19 +238,35 @@ fun Content.toMihonManga(): SManga {
  */
 fun SChapter.toKotoChapter(source: ContentSource, overrideNumber: Float? = null): ContentChapter {
     val chapterId = generateChapterId(url, source.name)
-    val finalNumber = overrideNumber ?: (if (chapter_number >= 0) chapter_number else 0f)
+    val finalNumber = overrideNumber ?: try {
+        number?.toFloatOrNullCompat() ?: (if (chapter_number >= 0) chapter_number else 0f)
+    } catch (e: NoSuchMethodError) {
+        if (chapter_number >= 0) chapter_number else 0f
+    }
     
-    android.util.Log.d("MihonDataConverters", "toKotoChapter: name='$name' url='$url' -> id=$chapterId number=$finalNumber")
+    val finalVolume = try {
+        volume?.toIntOrNull() ?: 0
+    } catch (e: NoSuchMethodError) {
+        0
+    }
+    
+    val finalScanlator = try {
+        scanlators.takeIf { it.isNotEmpty() }?.joinToString(", ") ?: scanlator
+    } catch (e: NoSuchMethodError) {
+        scanlator
+    }
+    
+    android.util.Log.d("MihonDataConverters", "toKotoChapter: name='$name' url='$url' -> id=$chapterId number=$finalNumber volume=$finalVolume")
     
     return ContentChapter(
         id = chapterId,
         title = name.takeIf { it.isNotBlank() },
         number = finalNumber,
-        volume = 0, // Mihon doesn't have volume numbers in SChapter
+        volume = finalVolume,
         url = url,
-        scanlator = scanlator,
+        scanlator = finalScanlator,
         uploadDate = date_upload,
-        branch = scanlator, // Use scanlator as branch for grouping
+        branch = finalScanlator, // Use scanlator as branch for grouping
         source = source,
     )
 }
@@ -200,6 +281,13 @@ fun ContentChapter.toMihonChapter(): SChapter {
         this.chapter_number = this@toMihonChapter.number
         this.date_upload = this@toMihonChapter.uploadDate
         this.scanlator = this@toMihonChapter.scanlator
+        try {
+            this.number = this@toMihonChapter.number.toString()
+            this.volume = this@toMihonChapter.volume.takeIf { it > 0 }?.toString()
+            this.scanlators = this@toMihonChapter.scanlator?.let { listOf(it) } ?: emptyList()
+        } catch (e: NoSuchMethodError) {
+            // Fallback
+        }
     }
 }
 

--- a/app/src/test/kotlin/org/skepsun/kototoro/extensions/runtime/ExternalExtensionMetadataSupportTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/extensions/runtime/ExternalExtensionMetadataSupportTest.kt
@@ -102,16 +102,20 @@ class ExternalExtensionMetadataSupportTest {
 	@Test
 	fun `getDeclaredSourceMetadataOrNull returns grouped manifest values`() {
 		val metaData = mockk<Bundle>()
+		every { metaData.containsKey(any()) } returns false
 		every { metaData.getString("source.class") } returns "org.example.Source"
 		every { metaData.getString("source.factory") } returns null
 		every { metaData.getInt("ext.nsfw", 0) } returns 1
 		val emptyMeta = mockk<Bundle>()
+		every { emptyMeta.containsKey(any()) } returns false
 		every { emptyMeta.getString(any()) } returns null
 
 		assertEquals(
 			ExternalExtensionMetadataSupport.DeclaredSourceMetadata(
 				sourceClassName = "org.example.Source",
 				isNsfw = true,
+				contentWarning = null,
+				libVersionOverride = null,
 			),
 			ExternalExtensionMetadataSupport.getDeclaredSourceMetadataOrNull(
 				metaData = metaData,
@@ -128,5 +132,28 @@ class ExternalExtensionMetadataSupportTest {
 				nsfwKey = "ext.nsfw",
 			),
 		)
+	}
+
+	@Test
+	fun `getDeclaredSourceMetadataOrNull handles TachiyomiX 1_6 metadata`() {
+		val metaData = mockk<Bundle>()
+		every { metaData.containsKey(any()) } returns false
+		every { metaData.getString("source.class") } returns "org.example.Source"
+		every { metaData.getString("source.factory") } returns null
+		every { metaData.containsKey("tachiyomix.contentWarning") } returns true
+		every { metaData.getInt("tachiyomix.contentWarning") } returns 2
+		every { metaData.containsKey("tachiyomix.extensionLib") } returns true
+		every { metaData.get("tachiyomix.extensionLib") } returns "1.6"
+
+		val result = ExternalExtensionMetadataSupport.getDeclaredSourceMetadataOrNull(
+			metaData = metaData,
+			sourceClassKey = "source.class",
+			sourceFactoryKey = "source.factory",
+			nsfwKey = "ext.nsfw",
+		)
+		assertEquals("org.example.Source", result?.sourceClassName)
+		assertTrue(result?.isNsfw == true)
+		assertEquals(2, result?.contentWarning)
+		assertEquals(1.6, result?.libVersionOverride)
 	}
 }

--- a/app/src/test/kotlin/org/skepsun/kototoro/mihon/model/LegacyExtensionCompatibilityTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/mihon/model/LegacyExtensionCompatibilityTest.kt
@@ -1,0 +1,106 @@
+package org.skepsun.kototoro.mihon.model
+
+import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.skepsun.kototoro.parsers.model.ContentRating
+
+class LegacyExtensionCompatibilityTest {
+
+	// A mock that mimics a legacy extension compiled only with SManga v1 properties
+	class LegacySMangaMock : SManga {
+		override lateinit var url: String
+		override lateinit var title: String
+		override var artist: String? = null
+		override var author: String? = null
+		override var description: String? = null
+		override var genre: String? = null
+		override var status: Int = 0
+		override var thumbnail_url: String? = null
+		override var update_strategy: UpdateStrategy = UpdateStrategy.ALWAYS_UPDATE
+		override var initialized: Boolean = false
+	}
+
+	// A mock that mimics a legacy extension compiled only with SChapter v1 properties
+	class LegacySChapterMock : SChapter {
+		override lateinit var url: String
+		override lateinit var name: String
+		override var chapter_number: Float = -1f
+		override var scanlator: String? = null
+		override var date_upload: Long = 0
+	}
+
+	@Test
+	fun `toKotoContent handles legacy SManga models seamlessly`() {
+		val catalogueSource = mockk<CatalogueSource>()
+		every { catalogueSource.id } returns 101L
+		every { catalogueSource.name } returns "Legacy Source"
+		every { catalogueSource.lang } returns "en"
+		every { catalogueSource.supportsLatest } returns true
+
+		val source = MihonMangaSource(
+			catalogueSource = catalogueSource,
+			pkgName = "org.example.legacy",
+			isNsfw = true,
+		)
+
+		val legacyManga = LegacySMangaMock().apply {
+			url = "/legacy-url"
+			title = "Legacy Title"
+			genre = "Sci-Fi, Comedy, Adventure"
+			status = SManga.ONGOING
+			initialized = true
+		}
+
+		val content = legacyManga.toKotoContent(source)
+
+		// Assertions check fallback logic is executed seamlessly:
+		assertEquals("Legacy Title", content.title)
+		assertEquals(emptySet<String>(), content.altTitles) // Defaults to empty list
+		assertEquals(ContentRating.ADULT, content.contentRating) // Overridden by source.isNsfw = true
+		
+		// Tags must be parsed by splitting the legacy genre string
+		val tagTitles = content.tags.map { it.title }
+		assertEquals(3, tagTitles.size)
+		assertTrue(tagTitles.contains("Sci-Fi"))
+		assertTrue(tagTitles.contains("Comedy"))
+		assertTrue(tagTitles.contains("Adventure"))
+	}
+
+	@Test
+	fun `toKotoChapter handles legacy SChapter models seamlessly`() {
+		val catalogueSource = mockk<CatalogueSource>()
+		every { catalogueSource.id } returns 101L
+		every { catalogueSource.name } returns "Legacy Source"
+		every { catalogueSource.lang } returns "en"
+		every { catalogueSource.supportsLatest } returns true
+
+		val source = MihonMangaSource(
+			catalogueSource = catalogueSource,
+			pkgName = "org.example.legacy",
+			isNsfw = false,
+		)
+
+		val legacyChapter = LegacySChapterMock().apply {
+			url = "/legacy-chapter-url"
+			name = "Legacy Chapter Title"
+			chapter_number = 42.5f
+			scanlator = "Legacy Scanlator Group"
+			date_upload = 9876543210L
+		}
+
+		val kotoChapter = legacyChapter.toKotoChapter(source)
+
+		// Assertions check fallback logic is executed seamlessly:
+		assertEquals(42.5f, kotoChapter.number) // Falls back to chapter_number
+		assertEquals(0, kotoChapter.volume) // Falls back to 0
+		assertEquals("Legacy Scanlator Group", kotoChapter.scanlator) // Falls back to scanlator string
+		assertEquals("Legacy Scanlator Group", kotoChapter.branch)
+	}
+}


### PR DESCRIPTION
I worked on this since there was already one source that got broken due the new Tachiyomix 1.6 standard, which effectively changed how the API behaves. Please carefully inspect it and make sure it doesn't collides with anything that may be on the workings. 
This pull request introduces several backward-compatible enhancements and new properties to the core data models (`SManga`, `SChapter`) and improves extension metadata handling. The changes primarily add new fields and default implementations for richer metadata support, improve compatibility with future versions, and enhance extension manifest parsing.

**Model Enhancements and Backward Compatibility:**

* Added new properties to `SManga` and `SChapter` interfaces (e.g., `genres`, `altTitles`, `banner`, `contentRating`, `score`, `readingMode`, `memo`, `number`, `volume`, `scanlators`, `note`) with default implementations to maintain backward compatibility. This allows richer metadata handling while supporting older extensions. [[1]](diffhunk://#diff-37bb0274f1664916fc3e99b16855f2b4ea368857001752a9bff1b2e06a420324L33-R67) [[2]](diffhunk://#diff-37bb0274f1664916fc3e99b16855f2b4ea368857001752a9bff1b2e06a420324R80-R94) [[3]](diffhunk://#diff-433a8e171811532a763ef194e97c7f92f0991e0591a15538161ad1db3dd39f03R24-R63) [[4]](diffhunk://#diff-433a8e171811532a763ef194e97c7f92f0991e0591a15538161ad1db3dd39f03R87-R128)
* Updated `SMangaImpl` and `SChapterImpl` to back the new properties and ensure correct fallback to legacy fields. Also added a compatibility float parsing helper for chapter numbers. [[1]](diffhunk://#diff-37bb0274f1664916fc3e99b16855f2b4ea368857001752a9bff1b2e06a420324R135-R156) [[2]](diffhunk://#diff-433a8e171811532a763ef194e97c7f92f0991e0591a15538161ad1db3dd39f03R87-R128)

**Extension Metadata and Loader Improvements:**

* Enhanced extension manifest parsing to support new metadata keys: `tachiyomix.contentWarning`, `tachiyomix.extensionLib`, and `tachiyomix.name`. The loader now prefers these fields for content warnings, library version overrides, and extension naming. [[1]](diffhunk://#diff-ce83d4f7041e52c82c3613a4f3db24543d3550eec7fe6ff23f7d0a72a450bfe2R11-R12) [[2]](diffhunk://#diff-ce83d4f7041e52c82c3613a4f3db24543d3550eec7fe6ff23f7d0a72a450bfe2R44-R84) [[3]](diffhunk://#diff-e11a2ccb3debcd65ce74b3f149d9385eb123543e3ceea2d18ff5dcfed766f430R51-R53) [[4]](diffhunk://#diff-e11a2ccb3debcd65ce74b3f149d9385eb123543e3ceea2d18ff5dcfed766f430L184-L194) [[5]](diffhunk://#diff-e11a2ccb3debcd65ce74b3f149d9385eb123543e3ceea2d18ff5dcfed766f430R197-R209) [[6]](diffhunk://#diff-e11a2ccb3debcd65ce74b3f149d9385eb123543e3ceea2d18ff5dcfed766f430R249-R267) [[7]](diffhunk://#diff-e11a2ccb3debcd65ce74b3f149d9385eb123543e3ceea2d18ff5dcfed766f430L265-R286)

**Data Conversion and Compatibility:**

* Updated `MihonDataConverters.kt` to use the new properties and provide robust fallbacks for missing methods, ensuring compatibility with both new and legacy extensions. This includes improved genre, alternate title, banner, and content rating extraction and mapping. [[1]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffR6) [[2]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffL43-L61) [[3]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffR122-R125) [[4]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffL88-R140) [[5]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffL161-R230)

**Enumerations:**

* Introduced new enums for `ContentRating` and `ReadingMode` in `SManga` for standardized content classification and reading direction.

**Utility Improvements:**

* Added a helper function for robust string-to-float parsing to handle non-standard chapter number formats. [[1]](diffhunk://#diff-433a8e171811532a763ef194e97c7f92f0991e0591a15538161ad1db3dd39f03R87-R128) [[2]](diffhunk://#diff-a04a4bcc6c3032c27f67055af2950f9856a633343e07b3727b78c5758e7a50ffR6)

These changes collectively make the codebase more extensible, maintainable, and compatible with future enhancements while ensuring existing extensions continue to function correctly.