### PR TITLE
Enhance local content handling and chapter navigation

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/backups/data/BackupRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/backups/data/BackupRepository.kt
@@ -546,8 +546,16 @@ class BackupRepository @Inject constructor(
                     }
                 }
 
-                BackupSection.SETTINGS -> sectionInput.readMap().let {
-                    settings.upsertAll(it)
+                BackupSection.SETTINGS -> sectionInput.readMap().let { map ->
+                    val isKototoro = backupIndex?.appId == org.skepsun.kototoro.BuildConfig.APPLICATION_ID
+                    val finalMap = if (isKototoro) {
+                        map
+                    } else {
+                        map.toMutableMap().apply {
+                            this[AppSettings.KEY_DOWNLOADS_MAX_ACTIVE_SERIES] = 5
+                        }
+                    }
+                    settings.upsertAll(finalMap)
                     CompositeResult.success()
                 }
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
@@ -1309,6 +1309,10 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		get() = prefs.getSafeInt(KEY_DOWNLOADS_THREADS, readerThreads).coerceIn(1, 10)
 		set(value) = prefs.edit { putInt(KEY_DOWNLOADS_THREADS, value.coerceIn(1, 10)) }
 
+	var downloadMaxActiveSeries: Int
+		get() = prefs.getSafeInt(KEY_DOWNLOADS_MAX_ACTIVE_SERIES, 5).coerceIn(1, UNLIMITED_SERIES)
+		set(value) = prefs.edit { putInt(KEY_DOWNLOADS_MAX_ACTIVE_SERIES, value.coerceIn(1, UNLIMITED_SERIES)) }
+
 	var downloadRequestDelayMs: Int
 		get() = prefs.getSafeInt(KEY_DOWNLOADS_REQUEST_DELAY, DOWNLOADS_REQUEST_DELAY_DEFAULT).coerceIn(0, 5000)
 		set(value) = prefs.edit { putInt(KEY_DOWNLOADS_REQUEST_DELAY, value.coerceIn(0, 5000)) }
@@ -2139,6 +2143,8 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		const val KEY_DOWNLOADS_ALIGN_READER = "downloads_align_reader"
 		const val KEY_DOWNLOADS_AUTO_RETRY = "downloads_auto_retry"
 		const val KEY_DOWNLOADS_THREADS = "downloads_threads"
+		const val KEY_DOWNLOADS_MAX_ACTIVE_SERIES = "downloads_max_active_series"
+		const val UNLIMITED_SERIES = 11
 		const val KEY_DOWNLOADS_REQUEST_DELAY = "downloads_request_delay"
 		const val KEY_DOWNLOADS_RETRY_COUNT = "downloads_retry_count"
 		const val KEY_DOWNLOADS_RETRY_DELAY = "downloads_retry_delay"

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
@@ -2880,17 +2880,32 @@ class DetailsViewModel @Inject constructor(
 		.withErrorHandling()
 		.stateIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, null)
 
-	@Suppress("unused")
 	private val readingStateSync: StateFlow<ReaderState?> = combine(
 		mangaDetails,
 		history,
-	) { details, h ->
-		if (h != null && org.skepsun.kototoro.list.domain.ReadingProgress.isCompleted(h.percent)) {
-			return@combine null
-		}
+		selectedBranch,
+	) { details, h, branch ->
 		val chapter = details?.allChapters?.findChapterByHistory(h)
 		if (h != null && chapter != null) {
-			ReaderState(h.copy(chapterId = chapter.id))
+			val isCompleted = h.percent >= 0.99999f
+			if (isCompleted && details != null) {
+				val branchChapters = details.allChapters
+					.filter { it.branch == branch }
+					.sortedBy { it.number }
+				val index = branchChapters.indexOfFirst { it.id == chapter.id }
+				if (index != -1 && index + 1 < branchChapters.size) {
+					val nextChapter = branchChapters[index + 1]
+					ReaderState(
+						chapterId = nextChapter.id,
+						page = 0,
+						scroll = 0,
+					)
+				} else {
+					null
+				}
+			} else {
+				ReaderState(h.copy(chapterId = chapter.id))
+			}
 		} else {
 			null
 		}

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
@@ -2901,7 +2901,7 @@ class DetailsViewModel @Inject constructor(
 						scroll = 0,
 					)
 				} else {
-					null
+					ReaderState(h.copy(chapterId = chapter.id))
 				}
 			} else {
 				ReaderState(h.copy(chapterId = chapter.id))

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
@@ -99,7 +99,24 @@ internal fun openDetailsReader(
 			}
 
 			if (matchedChapter != null) {
-				intentBuilder.state(ReaderState(history.copy(chapterId = matchedChapter.id)))
+				val isCompleted = history.percent >= 0.99999f
+				val targetState = if (isCompleted) {
+					val sortedChapters = chapters?.sortedBy { it.number } ?: emptyList()
+					val index = sortedChapters.indexOfFirst { it.id == matchedChapter.id }
+					if (index != -1 && index + 1 < sortedChapters.size) {
+						val nextChapter = sortedChapters[index + 1]
+						ReaderState(
+							chapterId = nextChapter.id,
+							page = 0,
+							scroll = 0,
+						)
+					} else {
+						ReaderState(history.copy(chapterId = matchedChapter.id))
+					}
+				} else {
+					ReaderState(history.copy(chapterId = matchedChapter.id))
+				}
+				intentBuilder.state(targetState)
 			}
 		}
 	}.getOrElse { }

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/model/HistoryInfo.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/model/HistoryInfo.kt
@@ -42,10 +42,21 @@ fun HistoryInfo(
 	} else {
 		manga?.chapters?.get(branch)
 	}
-	val currentChapter = if (history != null && !chapters.isNullOrEmpty()) {
+	var currentChapter = if (history != null && !chapters.isNullOrEmpty()) {
 		chapters.findChapterByHistory(history)?.let(chapters::indexOf) ?: -1
 	} else {
 		-2
+	}
+	if (history != null && history.percent >= 0.99999f && !chapters.isNullOrEmpty() && currentChapter >= 0) {
+		val sortedChapters = chapters.sortedBy { it.number }
+		val currentInSorted = sortedChapters.indexOfFirst { it.id == chapters[currentChapter].id }
+		if (currentInSorted != -1 && currentInSorted + 1 < sortedChapters.size) {
+			val nextChapter = sortedChapters[currentInSorted + 1]
+			val nextIndexInRaw = chapters.indexOfFirst { it.id == nextChapter.id }
+			if (nextIndexInRaw != -1) {
+				currentChapter = nextIndexInRaw
+			}
+		}
 	}
 	// Check if chapter is missing
 	// For EPUB chapters, also check if the history chapter ID is a parent chapter ID

--- a/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/ActiveDownloadRegistry.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/ActiveDownloadRegistry.kt
@@ -1,0 +1,43 @@
+package org.skepsun.kototoro.download.ui.worker
+
+import java.util.UUID
+
+object ActiveDownloadRegistry {
+	private val activeWorkers = LinkedHashSet<UUID>()
+	private val pausedWorkers = HashSet<UUID>()
+
+	@Synchronized
+	fun register(id: UUID, isPaused: Boolean) {
+		activeWorkers.add(id)
+		if (isPaused) {
+			pausedWorkers.add(id)
+		} else {
+			pausedWorkers.remove(id)
+		}
+	}
+
+	@Synchronized
+	fun unregister(id: UUID) {
+		activeWorkers.remove(id)
+		pausedWorkers.remove(id)
+	}
+
+	@Synchronized
+	fun setPaused(id: UUID, paused: Boolean) {
+		if (paused) {
+			pausedWorkers.add(id)
+		} else {
+			pausedWorkers.remove(id)
+		}
+	}
+
+	@Synchronized
+	fun isTurn(id: UUID, limit: Int): Boolean {
+		if (limit == 11) { // AppSettings.UNLIMITED_SERIES
+			return true
+		}
+		val runningList = activeWorkers.filter { it !in pausedWorkers }
+		val index = runningList.indexOf(id)
+		return index >= 0 && index < limit
+	}
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
@@ -251,12 +251,25 @@ class DownloadWorker @AssistedInject constructor(
 				"displayMangaId=${executionContext.displayMangaId} kind=${task.kind} " +
 				"chapters=${executionContext.executionManga.chapters?.size ?: 0} taskChapters=${task.executionChapterIds?.size ?: -1}",
 		)
+		
+		ActiveDownloadRegistry.register(id, isPaused = task.isPaused)
+		
+		val pausingHandle = PausingHandle()
+		if (task.isPaused) {
+			Log.i("DownloadWorker", "doWork start paused: workId=$id mangaId=${executionContext.executionManga.id}")
+			pausingHandle.pause()
+		}
+		
+		val pausingReceiver = PausingReceiver(id, pausingHandle)
+		ContextCompat.registerReceiver(
+			applicationContext,
+			pausingReceiver,
+			PausingReceiver.createIntentFilter(id),
+			ContextCompat.RECEIVER_NOT_EXPORTED,
+		)
+		
 		try {
-			val pausingHandle = PausingHandle()
-			if (task.isPaused) {
-				Log.i("DownloadWorker", "doWork start paused: workId=$id mangaId=${executionContext.executionManga.id}")
-				pausingHandle.pause()
-			}
+			checkIsPaused()
 			withContext(pausingHandle) {
 				when (task.kind) {
 					DownloadTaskKind.DOWNLOAD -> {
@@ -325,6 +338,11 @@ class DownloadWorker @AssistedInject constructor(
 				).toWorkData(),
 			)
 		} finally {
+			ActiveDownloadRegistry.unregister(id)
+			try {
+				applicationContext.unregisterReceiver(pausingReceiver)
+			} catch (_: Exception) {
+			}
 			notificationManager.cancel(id.hashCode())
 		}
 	}
@@ -355,14 +373,7 @@ class DownloadWorker @AssistedInject constructor(
 		}
 		Log.d("DownloadWorker", "downloadContentImpl start: mangaId=${subject.id} title=${subject.title} excluded=${excludedIds.size}")
 		val chaptersToSkip = excludedIds.toMutableSet()
-		val pausingReceiver = PausingReceiver(id, PausingHandle.current())
 		mangaLock.withLock(subject) {
-			ContextCompat.registerReceiver(
-				applicationContext,
-				pausingReceiver,
-				PausingReceiver.createIntentFilter(id),
-				ContextCompat.RECEIVER_NOT_EXPORTED,
-			)
 			var destination = localContentRepository.getOutputDir(subject, task.destination)
 			checkNotNull(destination) { applicationContext.getString(R.string.cannot_find_available_storage) }
 			Log.d("DownloadWorker", "downloadContentImpl outputDir=${destination.absolutePath}")
@@ -465,7 +476,6 @@ class DownloadWorker @AssistedInject constructor(
 				throw e
 			} finally {
 				withContext(NonCancellable) {
-					applicationContext.unregisterReceiver(pausingReceiver)
 					output?.closeQuietly()
 					output?.cleanup()
 					val tempFiles = destination.listFiles(TempFileFilter())
@@ -983,13 +993,20 @@ class DownloadWorker @AssistedInject constructor(
 
 	private suspend fun checkIsPaused() {
 		val pausingHandle = PausingHandle.current()
-		if (pausingHandle.isPaused) {
-			publishState(currentState.copy(isPaused = true, eta = -1L, isStuck = false))
-			try {
-				pausingHandle.awaitResumed()
-			} finally {
-				publishState(currentState.copy(isPaused = false))
+		while (true) {
+			if (pausingHandle.isPaused) {
+				publishState(currentState.copy(isPaused = true, eta = -1L, isStuck = false))
+				try {
+					pausingHandle.awaitResumed()
+				} finally {
+					publishState(currentState.copy(isPaused = false))
+				}
 			}
+			val limit = settings.downloadMaxActiveSeries
+			if (ActiveDownloadRegistry.isTurn(id, limit)) {
+				break
+			}
+			delay(1000)
 		}
 	}
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
@@ -269,8 +269,8 @@ class DownloadWorker @AssistedInject constructor(
 		)
 		
 		try {
-			checkIsPaused()
 			withContext(pausingHandle) {
+				checkIsPaused()
 				when (task.kind) {
 					DownloadTaskKind.DOWNLOAD -> {
 						val resolvedContent = resolveExecutionContent(executionContext.executionManga)

--- a/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/DownloadWorker.kt
@@ -843,6 +843,11 @@ class DownloadWorker @AssistedInject constructor(
 				println("DownloadWorker: Not EPUB, using normal download")
 			}
 
+			val tempDir = File(destination, "tmp_${chapter.value.id}")
+			if (!tempDir.exists()) {
+				tempDir.mkdirs()
+			}
+
 			val pageCounter = AtomicInteger(0)
 			val successCounter = AtomicInteger(0)
 			channelFlow {
@@ -857,18 +862,28 @@ class DownloadWorker @AssistedInject constructor(
 					launch {
 						semaphore.withPermit {
 							val success = runFailsafe {
-								val url = repo.getPageUrl(page)
-								val file = cache[url]
-									?: downloadFile(repo, url, destination, page = page)
+								val prefix = String.format("%04d.", pageIndex)
+								val existingFile = tempDir.listFiles { _, name -> name.startsWith(prefix) }?.firstOrNull()
+								val file = if (existingFile != null && existingFile.length() > 0) {
+									existingFile
+								} else {
+									val url = repo.getPageUrl(page)
+									val downloadedFile = cache[url]
+										?: downloadFile(repo, url, destination, page = page)
+									val ext = downloadedFile.extension.takeIf { it != "tmp" } ?: "jpg"
+									val targetFile = File(tempDir, prefix + ext)
+									downloadedFile.copyTo(targetFile, overwrite = true)
+									if (downloadedFile.extension == "tmp") {
+										downloadedFile.deleteAwait()
+									}
+									targetFile
+								}
 								output.addPage(
 									chapter = chapter,
 									file = file,
 									pageNumber = pageIndex,
-									type = getMediaType(url, file),
+									type = getMediaType(file.name, file),
 								)
-								if (file.extension == "tmp") {
-									file.deleteAwait()
-								}
 								true
 							} ?: false
 							if (success) {
@@ -902,6 +917,7 @@ class DownloadWorker @AssistedInject constructor(
 				throw IOException("No pages downloaded for chapter: ${chapter.value.title ?: chapter.value.id}")
 			}
 			if (output.flushChapter(chapter.value)) {
+				tempDir.deleteRecursively()
 				runCatchingCancellable {
 					localStorageChanges.emit(LocalContentParser(output.rootFile).getContent(withDetails = false))
 				}.onFailure(Throwable::printStackTraceDebug)
@@ -1232,6 +1248,35 @@ class DownloadWorker @AssistedInject constructor(
 				cr.openSource(uri).use { input ->
 					file.sink(append = false).buffer().use {
 						it.writeAllCancellable(input)
+					}
+				}
+			} catch (e: Exception) {
+				file.delete()
+				throw e
+			}
+			return file
+		}
+		if (url.startsWith("zip:", ignoreCase = true) || url.startsWith("file+zip:", ignoreCase = true)) {
+			val uri = url.toUri()
+			val zipFile = when (uri.scheme) {
+				"zip" -> File(uri.schemeSpecificPart)
+				"file+zip" -> File(uri.host.orEmpty() + uri.path.orEmpty())
+				else -> throw IllegalArgumentException("Unsupported scheme: ${uri.scheme}")
+			}
+			val fragment = uri.fragment ?: ""
+			val ext = MimeTypes.getNormalizedExtension(fragment)
+			val file = destination.createTempFile(ext)
+			try {
+				runInterruptible(Dispatchers.IO) {
+					java.util.zip.ZipFile(zipFile).use { zip ->
+						val entry = checkNotNull(zip.getEntry(fragment)) {
+							"Zip entry not found: $fragment in ${zipFile.absolutePath}"
+						}
+						zip.getInputStream(entry).use { input ->
+							file.outputStream().use { output ->
+								input.copyTo(output)
+							}
+						}
 					}
 				}
 			} catch (e: Exception) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/PausingReceiver.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/download/ui/worker/PausingReceiver.kt
@@ -21,10 +21,16 @@ class PausingReceiver(
 			return
 		}
 		when (intent.action) {
-			ACTION_RESUME -> pausingHandle.resume()
+			ACTION_RESUME -> {
+				pausingHandle.resume()
+				ActiveDownloadRegistry.setPaused(id, false)
+			}
 			ACTION_SKIP -> pausingHandle.skip()
 			ACTION_SKIP_ALL -> pausingHandle.skipAll()
-			ACTION_PAUSE -> pausingHandle.pause()
+			ACTION_PAUSE -> {
+				pausingHandle.pause()
+				ActiveDownloadRegistry.setPaused(id, true)
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/data/LocalMangaRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/data/LocalMangaRepository.kt
@@ -200,7 +200,12 @@ class LocalMangaRepository @Inject constructor(
 
 	suspend fun delete(manga: Content): Boolean {
 		val file = if (manga.isLocal) {
-			manga.url.toUri().toFile()
+			val uri = manga.url.toUri()
+			if (uri.scheme == "file") {
+				File(requireNotNull(uri.path) { "File uri path is null: $uri" })
+			} else {
+				File(uri.schemeSpecificPart)
+			}
 		} else {
 			findSavedContent(manga, withDetails = false)?.file ?: return false
 		}

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/data/LocalMangaRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/data/LocalMangaRepository.kt
@@ -199,7 +199,11 @@ class LocalMangaRepository @Inject constructor(
 	}
 
 	suspend fun delete(manga: Content): Boolean {
-		val file = manga.url.toUri().toFile()
+		val file = if (manga.isLocal) {
+			manga.url.toUri().toFile()
+		} else {
+			findSavedContent(manga, withDetails = false)?.file ?: return false
+		}
 		val result = file.deleteAwait()
 		if (result) {
 			localContentIndex.delete(manga.id)

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
@@ -49,7 +49,12 @@ class DeleteReadChaptersUseCase @Inject constructor(
 			for (manga in list) {
 				launch(Dispatchers.Default) {
 					val task = runCatchingCancellable {
-						getDeletionTask(LocalContent(manga))
+						val localContent = if (manga.isLocal) {
+							LocalContent(manga)
+						} else {
+							localContentRepository.findSavedContent(manga)
+						}
+						localContent?.let { getDeletionTask(it) }
 					}.onFailure {
 						it.printStackTraceDebug()
 					}.getOrNull()

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
@@ -71,10 +71,14 @@ class DeleteReadChaptersUseCase @Inject constructor(
 	private suspend fun getDeletionTask(manga: LocalContent): DeletionTask? {
 		val history = historyRepository.getOne(manga.manga) ?: return null
 		val localChapters = getLocalChapters(manga)
+		val remoteMangaId = runCatchingCancellable {
+			localContentRepository.getRemoteContent(manga.manga)?.id
+		}.getOrNull() ?: manga.manga.id
 		val dbChapters = runCatchingCancellable {
-			db.getChaptersDao().findAll(manga.manga.id).toContentChapters()
+			db.getChaptersDao().findAll(remoteMangaId).toContentChapters()
 		}.getOrDefault(emptyList())
 		val combined = (localChapters + dbChapters).distinctBy { it.id }
+
 
 		val chapters = if (combined.any { it.id == history.chapterId }) {
 			combined

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
@@ -67,13 +67,19 @@ class DeleteReadChaptersUseCase @Inject constructor(
 
 	private suspend fun getDeletionTask(manga: LocalContent): DeletionTask? {
 		val history = historyRepository.getOne(manga.manga) ?: return null
-		val chapters = getAllChapters(manga)
+		val localChapters = getLocalChapters(manga)
+		val chapters = if (localChapters.any { it.id == history.chapterId }) {
+			localChapters
+		} else {
+			getAllChaptersRemote(manga, localChapters)
+		}
 		if (chapters.isEmpty()) {
 			return null
 		}
-		val historyChapter = chapters.findById(history.chapterId) ?: return null
+		val sortedChapters = chapters.sortedBy { it.number }
+		val historyChapter = sortedChapters.findById(history.chapterId) ?: return null
 		val branch = historyChapter.branch
-		val filteredChapters = chapters
+		val filteredChapters = sortedChapters
 			.filter { x -> x.branch == branch }
 			.takeWhile { it.id != historyChapter.id }
 		return if (filteredChapters.isEmpty()) {
@@ -86,20 +92,22 @@ class DeleteReadChaptersUseCase @Inject constructor(
 		}
 	}
 
-	private suspend fun getAllChapters(manga: LocalContent): List<ContentChapter> = runCatchingCancellable {
+	private suspend fun getLocalChapters(manga: LocalContent): List<ContentChapter> {
+		return manga.manga.chapters.let {
+			if (it.isNullOrEmpty()) {
+				runCatchingCancellable {
+					localContentRepository.getDetails(manga.manga).chapters
+				}.getOrNull()
+			} else {
+				it
+			}
+		}.orEmpty()
+	}
+
+	private suspend fun getAllChaptersRemote(manga: LocalContent, fallback: List<ContentChapter>): List<ContentChapter> = runCatchingCancellable {
 		val remoteContent = checkNotNull(localContentRepository.getRemoteContent(manga.manga))
 		checkNotNull(mangaRepositoryFactory.create(remoteContent.source).getDetails(remoteContent).chapters)
-	}.recoverCatchingCancellable {
-		checkNotNull(
-			manga.manga.chapters.let {
-				if (it.isNullOrEmpty()) {
-					localContentRepository.getDetails(manga.manga).chapters
-				} else {
-					it
-				}
-			},
-		)
-	}.getOrDefault(manga.manga.chapters.orEmpty())
+	}.getOrDefault(fallback)
 
 	private class DeletionTask(
 		val manga: LocalContent,

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCase.kt
@@ -19,11 +19,14 @@ import org.skepsun.kototoro.parsers.util.findById
 import org.skepsun.kototoro.parsers.util.recoverCatchingCancellable
 import org.skepsun.kototoro.parsers.util.runCatchingCancellable
 import javax.inject.Inject
+import org.skepsun.kototoro.core.db.MangaDatabase
+import org.skepsun.kototoro.core.db.entity.toContentChapters
 
 class DeleteReadChaptersUseCase @Inject constructor(
 	private val localContentRepository: LocalMangaRepository,
 	private val historyRepository: HistoryRepository,
 	private val mangaRepositoryFactory: ContentRepository.Factory,
+	private val db: MangaDatabase,
 ) {
 
 	suspend operator fun invoke(manga: Content): Int {
@@ -68,10 +71,15 @@ class DeleteReadChaptersUseCase @Inject constructor(
 	private suspend fun getDeletionTask(manga: LocalContent): DeletionTask? {
 		val history = historyRepository.getOne(manga.manga) ?: return null
 		val localChapters = getLocalChapters(manga)
-		val chapters = if (localChapters.any { it.id == history.chapterId }) {
-			localChapters
+		val dbChapters = runCatchingCancellable {
+			db.getChaptersDao().findAll(manga.manga.id).toContentChapters()
+		}.getOrDefault(emptyList())
+		val combined = (localChapters + dbChapters).distinctBy { it.id }
+
+		val chapters = if (combined.any { it.id == history.chapterId }) {
+			combined
 		} else {
-			getAllChaptersRemote(manga, localChapters)
+			getAllChaptersRemote(manga, combined)
 		}
 		if (chapters.isEmpty()) {
 			return null
@@ -82,12 +90,14 @@ class DeleteReadChaptersUseCase @Inject constructor(
 		val filteredChapters = sortedChapters
 			.filter { x -> x.branch == branch }
 			.takeWhile { it.id != historyChapter.id }
-		return if (filteredChapters.isEmpty()) {
+
+		val toDeleteIds = filteredChapters.ids().intersect(localChapters.ids())
+		return if (toDeleteIds.isEmpty()) {
 			null
 		} else {
 			DeletionTask(
 				manga = manga,
-				chaptersIds = filteredChapters.ids(),
+				chaptersIds = toDeleteIds,
 			)
 		}
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/local/domain/model/LocalManga.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/local/domain/model/LocalManga.kt
@@ -11,7 +11,13 @@ import java.io.File
 
 data class LocalContent(
 	val manga: Content,
-	val file: File = manga.url.toUri().toFile(),
+	val file: File = manga.url.toUri().let { uri ->
+		if (uri.scheme == "file") {
+			File(requireNotNull(uri.path) { "File uri path is null: $uri" })
+		} else {
+			File(uri.schemeSpecificPart)
+		}
+	},
 ) {
 
 	var createdAt: Long = -1L

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/ChaptersLoader.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/ChaptersLoader.kt
@@ -97,6 +97,10 @@ class ChaptersLoader @Inject constructor(
 
 	fun peekChapter(chapterId: Long): ContentChapter? = chapters[chapterId]
 
+	fun isChapterLocal(chapterId: Long): Boolean {
+		return chapters[chapterId]?.isLocalPageSource() ?: false
+	}
+
 	fun hasPages(chapterId: Long): Boolean {
 		return chapterId in chapterPages
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
@@ -794,6 +794,25 @@ class ReaderViewModel @Inject constructor(
                                 exception = e.mergeWith(exception)
                                 return@collect
                             }
+                        } else {
+                            val state = readingState.value!!
+                            if (chaptersLoader.isChapterLocal(state.chapterId)) {
+                                val loadedPages = chaptersLoader.getPages(state.chapterId)
+                                val hasRemotePages = loadedPages.any { 
+                                    val uri = android.net.Uri.parse(it.url)
+                                    val scheme = uri.scheme
+                                    scheme != "file" && scheme != "zip" && scheme != "file+zip" &&
+                                    scheme != "content" && scheme != "epub" && scheme != "localepub"
+                                }
+                                if (hasRemotePages) {
+                                    android.util.Log.d("ReaderViewModel", "Reloading chapter ${state.chapterId} pages from local storage")
+                                    try {
+                                        chaptersLoader.loadSingleChapter(state.chapterId)
+                                    } catch (e: Exception) {
+                                        exception = e.mergeWith(exception)
+                                    }
+                                }
+                            }
                         }
                         mangaDetails.value = details.filterChapters(selectedBranch.value)
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/DownloadsSettingsFragment.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/DownloadsSettingsFragment.kt
@@ -10,14 +10,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
@@ -178,6 +184,9 @@ fun DownloadsSettingsRoute(
     val isDownloadAutoRetryOnNetworkError =
         settings.observeAsState(AppSettings.KEY_DOWNLOADS_AUTO_RETRY) { isDownloadAutoRetryOnNetworkError }.value
     val downloadThreads = settings.observeAsState(AppSettings.KEY_DOWNLOADS_THREADS) { downloadThreads }.value
+    val downloadMaxActiveSeries =
+        settings.observeAsState(AppSettings.KEY_DOWNLOADS_MAX_ACTIVE_SERIES) { downloadMaxActiveSeries }.value
+    var showUncappedWarning by remember { mutableStateOf(false) }
     val downloadRequestDelayMs =
         settings.observeAsState(AppSettings.KEY_DOWNLOADS_REQUEST_DELAY) { downloadRequestDelayMs }.value
     val downloadRetryCount =
@@ -224,6 +233,7 @@ fun DownloadsSettingsRoute(
         isDownloadAlignedWithReader = isDownloadAlignedWithReader,
         isDownloadAutoRetryOnNetworkError = isDownloadAutoRetryOnNetworkError,
         downloadThreads = downloadThreads,
+        downloadMaxActiveSeries = downloadMaxActiveSeries,
         downloadRequestDelayMs = downloadRequestDelayMs,
         downloadRetryCount = downloadRetryCount,
         downloadRetryDelayMs = downloadRetryDelayMs,
@@ -232,6 +242,41 @@ fun DownloadsSettingsRoute(
         pagesDirectorySummary = pagesDirectorySummary,
         isPagesSavingAskEnabled = isPagesSavingAskEnabled,
     )
+
+    if (showUncappedWarning) {
+        AlertDialog(
+            onDismissRequest = {
+                settings.downloadMaxActiveSeries = 10
+                showUncappedWarning = false
+            },
+            title = {
+                Text(stringResource(R.string.download_max_active_series_warning_title))
+            },
+            text = {
+                Text(stringResource(R.string.download_max_active_series_warning_message))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        settings.downloadMaxActiveSeries = AppSettings.UNLIMITED_SERIES
+                        showUncappedWarning = false
+                    }
+                ) {
+                    Text(stringResource(R.string.continue_action))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        settings.downloadMaxActiveSeries = 10
+                        showUncappedWarning = false
+                    }
+                ) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        )
+    }
 
     DownloadsSettingsScreen(
         downloadsTitle = context.getString(R.string.downloads),
@@ -248,6 +293,15 @@ fun DownloadsSettingsRoute(
         onDownloadAlignReaderChange = { settings.isDownloadAlignedWithReader = it },
         onDownloadAutoRetryChange = { settings.isDownloadAutoRetryOnNetworkError = it },
         onDownloadThreadsChange = { settings.downloadThreads = it },
+        onDownloadMaxActiveSeriesChange = { newValue ->
+            if (newValue == AppSettings.UNLIMITED_SERIES) {
+                if (downloadMaxActiveSeries != AppSettings.UNLIMITED_SERIES) {
+                    showUncappedWarning = true
+                }
+            } else {
+                settings.downloadMaxActiveSeries = newValue
+            }
+        },
         onDownloadRequestDelayChange = { settings.downloadRequestDelayMs = it },
         onDownloadRetryCountChange = { settings.downloadRetryCount = it },
         onDownloadRetryDelayChange = { settings.downloadRetryDelayMs = it },

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/DownloadsSettingsScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/DownloadsSettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.skepsun.kototoro.R
+import org.skepsun.kototoro.core.prefs.AppSettings
 import org.skepsun.kototoro.core.prefs.DownloadFormat
 import org.skepsun.kototoro.core.prefs.TriStateOption
 
@@ -30,6 +31,7 @@ data class DownloadsSettingsUiState(
     val isDownloadAlignedWithReader: Boolean,
     val isDownloadAutoRetryOnNetworkError: Boolean,
     val downloadThreads: Int,
+    val downloadMaxActiveSeries: Int,
     val downloadRequestDelayMs: Int,
     val downloadRetryCount: Int,
     val downloadRetryDelayMs: Int,
@@ -55,6 +57,7 @@ fun DownloadsSettingsScreen(
     onDownloadAlignReaderChange: (Boolean) -> Unit,
     onDownloadAutoRetryChange: (Boolean) -> Unit,
     onDownloadThreadsChange: (Int) -> Unit,
+    onDownloadMaxActiveSeriesChange: (Int) -> Unit,
     onDownloadRequestDelayChange: (Int) -> Unit,
     onDownloadRetryCountChange: (Int) -> Unit,
     onDownloadRetryDelayChange: (Int) -> Unit,
@@ -137,6 +140,23 @@ fun DownloadsSettingsScreen(
                         summary = stringResource(R.string.download_threads_summary),
                         valueText = { it.toString() },
                         onValueChange = onDownloadThreadsChange,
+                    )
+                    SettingsSectionDivider()
+                    val uncappedText = stringResource(R.string.download_max_active_series_uncapped)
+                    SettingsSliderPreference(
+                        title = stringResource(R.string.download_max_active_series),
+                        value = state.downloadMaxActiveSeries,
+                        valueRange = 1..AppSettings.UNLIMITED_SERIES,
+                        step = 1,
+                        summary = stringResource(R.string.download_max_active_series_summary),
+                        valueText = {
+                            if (it == AppSettings.UNLIMITED_SERIES) {
+                                uncappedText
+                            } else {
+                                it.toString()
+                            }
+                        },
+                        onValueChange = onDownloadMaxActiveSeriesChange,
                     )
                     SettingsSectionDivider()
                     SettingsSliderPreference(

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/search/SettingsSearchHelper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/search/SettingsSearchHelper.kt
@@ -464,6 +464,7 @@ class SettingsSearchHelper @Inject constructor(
 			"downloads_align_reader" to R.string.download_align_reader,
 			"downloads_auto_retry" to R.string.download_auto_retry,
 			"downloads_threads" to R.string.download_threads,
+			"downloads_max_active_series" to R.string.download_max_active_series,
 			"downloads_request_delay" to R.string.download_request_delay,
 			"downloads_retry_count" to R.string.download_retry_count,
 			"downloads_retry_delay" to R.string.download_retry_delay,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2666,6 +2666,11 @@
 
     <string name="download_threads">Download threads</string>
     <string name="download_threads_summary">Number of concurrent image downloads (1-10)</string>
+    <string name="download_max_active_series">Concurrent series downloads</string>
+    <string name="download_max_active_series_summary">Limit the number of active downloading series</string>
+    <string name="download_max_active_series_uncapped">Uncapped</string>
+    <string name="download_max_active_series_warning_title">⚠️ DANGER: Risk of Permanent Ban</string>
+    <string name="download_max_active_series_warning_message">Activating uncapped concurrent downloads will cause aggressive, rapid requests to the source\'s website. This behavior is often detected as a DDoS attack and HIGHLY increases the risk of:\n\n1. Immediate and severe rate limiting\n2. Permanent IP bans from the source\n3. Blacklisting your device from accessing their content entirely.\n\nDo NOT proceed unless you fully understand the consequences and accept the risk of losing access to this source.</string>
     <string name="download_request_delay">Download request delay</string>
     <string name="download_request_delay_summary">Delay between image requests in milliseconds (0-5000)</string>
     <string name="download_retry_count">Download retry count</string>

--- a/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
@@ -1,0 +1,147 @@
+package org.skepsun.kototoro.local.domain
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.skepsun.kototoro.core.model.ContentHistory
+import org.skepsun.kototoro.core.model.LocalMangaSource
+import org.skepsun.kototoro.core.parser.ContentRepository
+import org.skepsun.kototoro.history.data.HistoryRepository
+import org.skepsun.kototoro.local.data.LocalMangaRepository
+import org.skepsun.kototoro.parsers.model.Content
+import org.skepsun.kototoro.parsers.model.ContentChapter
+import java.time.Instant
+
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import java.io.File
+
+class DeleteReadChaptersUseCaseTest {
+
+	private val localContentRepository = mockk<LocalMangaRepository>(relaxed = true)
+	private val historyRepository = mockk<HistoryRepository>(relaxed = true)
+	private val mangaRepositoryFactory = mockk<ContentRepository.Factory>(relaxed = true)
+
+	private val useCase = DeleteReadChaptersUseCase(
+		localContentRepository,
+		historyRepository,
+		mangaRepositoryFactory
+	)
+
+	@BeforeEach
+	fun setUp() {
+		mockkStatic(Uri::class)
+		val mockUri = mockk<Uri>()
+		every { Uri.parse(any()) } returns mockUri
+		every { mockUri.scheme } returns "file"
+		every { mockUri.path } returns "/tmp/manga"
+	}
+
+	@AfterEach
+	fun tearDown() {
+		unmockkStatic(Uri::class)
+	}
+
+	private val source = LocalMangaSource
+
+	private fun createChapter(id: Long, number: Float, branch: String? = null): ContentChapter {
+		return ContentChapter(
+			id = id,
+			title = "Chapter $number",
+			number = number,
+			volume = 0,
+			url = "file:///tmp/manga/chapter/$id",
+			scanlator = null,
+			uploadDate = 0L,
+			branch = branch,
+			source = source
+		)
+	}
+
+	private fun createContent(id: Long, chapters: List<ContentChapter>): Content {
+		return Content(
+			id = id,
+			title = "Manga $id",
+			altTitles = emptySet(),
+			url = "file:///tmp/manga/$id",
+			publicUrl = "file:///tmp/manga/$id",
+			rating = 0f,
+			contentRating = null,
+			coverUrl = null,
+			tags = emptySet(),
+			state = null,
+			authors = emptySet(),
+			chapters = chapters,
+			source = source
+		)
+	}
+
+	@Test
+	fun `local chapters containing history chapter ID bypasses network call and deletes correctly`() = runTest {
+		// Arrange: 3 chapters (chronological order)
+		val chapters = listOf(
+			createChapter(1L, 1f),
+			createChapter(2L, 2f),
+			createChapter(3L, 3f)
+		)
+		val manga = createContent(100L, chapters)
+
+		coEvery { historyRepository.getOne(manga) } returns ContentHistory(
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+			chapterId = 2L, // read up to chapter 2
+			page = 0,
+			scroll = 0,
+			percent = 1f,
+			chaptersCount = 3
+		)
+		coEvery { localContentRepository.getList(0, null, null) } returns listOf(manga)
+
+		// Act
+		val deletedCount = useCase.invoke()
+
+		// Assert: should delete chapter 1, keep 2 and 3
+		assertEquals(1, deletedCount)
+		coVerify { localContentRepository.deleteChapters(manga, setOf(1L)) }
+		coVerify(exactly = 0) { mangaRepositoryFactory.create(any()) }
+		coVerify(exactly = 0) { localContentRepository.getRemoteContent(any()) }
+	}
+
+	@Test
+	fun `chapters are sorted chronologically before deletion to prevent deleting newer unread chapters`() = runTest {
+		// Arrange: raw chapters in reverse order (newest first)
+		val chapters = listOf(
+			createChapter(3L, 3f),
+			createChapter(2L, 2f),
+			createChapter(1L, 1f)
+		)
+		val manga = createContent(100L, chapters)
+
+		coEvery { historyRepository.getOne(manga) } returns ContentHistory(
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+			chapterId = 2L, // read up to chapter 2
+			page = 0,
+			scroll = 0,
+			percent = 1f,
+			chaptersCount = 3
+		)
+		coEvery { localContentRepository.getList(0, null, null) } returns listOf(manga)
+
+		// Act
+		val deletedCount = useCase.invoke()
+
+		// Assert: after sorting chronologically, list is [1, 2, 3]. History is 2.
+		// So we take chapters before 2 (which is 1). It must delete 1, NOT 3!
+		assertEquals(1, deletedCount)
+		coVerify { localContentRepository.deleteChapters(manga, setOf(1L)) }
+		coVerify(exactly = 0) { localContentRepository.deleteChapters(manga, setOf(3L)) }
+	}
+}

--- a/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
@@ -14,6 +14,7 @@ import org.skepsun.kototoro.local.data.LocalMangaRepository
 import org.skepsun.kototoro.parsers.model.Content
 import org.skepsun.kototoro.parsers.model.ContentChapter
 import java.time.Instant
+import org.skepsun.kototoro.core.db.MangaDatabase
 
 import android.net.Uri
 import io.mockk.every
@@ -28,11 +29,13 @@ class DeleteReadChaptersUseCaseTest {
 	private val localContentRepository = mockk<LocalMangaRepository>(relaxed = true)
 	private val historyRepository = mockk<HistoryRepository>(relaxed = true)
 	private val mangaRepositoryFactory = mockk<ContentRepository.Factory>(relaxed = true)
+	private val db = mockk<MangaDatabase>(relaxed = true)
 
 	private val useCase = DeleteReadChaptersUseCase(
 		localContentRepository,
 		historyRepository,
-		mangaRepositoryFactory
+		mangaRepositoryFactory,
+		db
 	)
 
 	@BeforeEach
@@ -42,6 +45,7 @@ class DeleteReadChaptersUseCaseTest {
 		every { Uri.parse(any()) } returns mockUri
 		every { mockUri.scheme } returns "file"
 		every { mockUri.path } returns "/tmp/manga"
+		coEvery { db.getChaptersDao().findAll(any()) } returns emptyList()
 	}
 
 	@AfterEach
@@ -143,5 +147,54 @@ class DeleteReadChaptersUseCaseTest {
 		assertEquals(1, deletedCount)
 		coVerify { localContentRepository.deleteChapters(manga, setOf(1L)) }
 		coVerify(exactly = 0) { localContentRepository.deleteChapters(manga, setOf(3L)) }
+	}
+
+	@Test
+	fun `history chapter not downloaded but in database deletes successfully`() = runTest {
+		// Arrange: 3 chapters (chronological order)
+		val localChapters = listOf(
+			createChapter(1L, 1f),
+			createChapter(2L, 2f)
+		)
+		// Chapter 3 is not downloaded (online) and is the current history chapter
+		val dbChapters = listOf(
+			createChapter(1L, 1f),
+			createChapter(2L, 2f),
+			createChapter(3L, 3f)
+		).map {
+			org.skepsun.kototoro.core.db.entity.ChapterEntity(
+				chapterId = it.id,
+				mangaId = 100L,
+				title = it.title.orEmpty(),
+				number = it.number,
+				volume = it.volume,
+				url = it.url,
+				scanlator = it.scanlator,
+				uploadDate = it.uploadDate,
+				branch = it.branch,
+				source = it.source.name,
+				index = 0
+			)
+		}
+		val manga = createContent(100L, localChapters)
+
+		coEvery { historyRepository.getOne(manga) } returns ContentHistory(
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+			chapterId = 3L, // read up to chapter 3 (online)
+			page = 0,
+			scroll = 0,
+			percent = 1f,
+			chaptersCount = 3
+		)
+		coEvery { db.getChaptersDao().findAll(100L) } returns dbChapters
+		coEvery { localContentRepository.getList(0, null, null) } returns listOf(manga)
+
+		// Act
+		val deletedCount = useCase.invoke()
+
+		// Assert: should delete chapter 1 and 2, which are the downloaded ones before history chapter 3
+		assertEquals(2, deletedCount)
+		coVerify { localContentRepository.deleteChapters(manga, setOf(1L, 2L)) }
 	}
 }

--- a/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
@@ -197,4 +197,74 @@ class DeleteReadChaptersUseCaseTest {
 		assertEquals(2, deletedCount)
 		coVerify { localContentRepository.deleteChapters(manga, setOf(1L, 2L)) }
 	}
+
+	@Test
+	fun `history chapter in database for remote downloaded manga deletes successfully`() = runTest {
+		val remoteSource = mockk<org.skepsun.kototoro.parsers.model.ContentSource>()
+		every { remoteSource.name } returns "RemoteSource"
+		every { remoteSource.contentType } returns org.skepsun.kototoro.parsers.model.ContentType.MANGA
+
+		val localChapters = listOf(
+			ContentChapter(
+				id = 1L,
+				title = "Chapter 1",
+				number = 1f,
+				volume = 0,
+				url = "file:///tmp/manga/chapter/1",
+				scanlator = null,
+				uploadDate = 0L,
+				branch = null,
+				source = remoteSource
+			),
+			ContentChapter(
+				id = 2L,
+				title = "Chapter 2",
+				number = 2f,
+				volume = 0,
+				url = "file:///tmp/manga/chapter/2",
+				scanlator = null,
+				uploadDate = 0L,
+				branch = null,
+				source = remoteSource
+			)
+		)
+		val manga = Content(
+			id = 100L,
+			title = "Remote Manga 100",
+			altTitles = emptySet(),
+			url = "/manga/100",
+			publicUrl = "/manga/100",
+			rating = 0f,
+			contentRating = null,
+			coverUrl = null,
+			tags = emptySet(),
+			state = null,
+			authors = emptySet(),
+			chapters = localChapters,
+			source = remoteSource
+		)
+		val localContent = org.skepsun.kototoro.local.domain.model.LocalContent(
+			manga = manga,
+			file = File("/tmp/manga/100")
+		)
+
+		coEvery { historyRepository.getOne(manga) } returns ContentHistory(
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+			chapterId = 2L, // read up to chapter 2
+			page = 0,
+			scroll = 0,
+			percent = 1f,
+			chaptersCount = 2
+		)
+		coEvery { localContentRepository.getList(0, null, null) } returns listOf(manga)
+		coEvery { localContentRepository.findSavedContent(manga) } returns localContent
+
+		// Act
+		val deletedCount = useCase.invoke()
+
+		// Assert: should delete chapter 1
+		assertEquals(1, deletedCount)
+		coVerify { localContentRepository.deleteChapters(manga, setOf(1L)) }
+	}
 }

--- a/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/local/domain/DeleteReadChaptersUseCaseTest.kt
@@ -46,6 +46,7 @@ class DeleteReadChaptersUseCaseTest {
 		every { mockUri.scheme } returns "file"
 		every { mockUri.path } returns "/tmp/manga"
 		coEvery { db.getChaptersDao().findAll(any()) } returns emptyList()
+		coEvery { localContentRepository.getRemoteContent(any()) } returns null
 	}
 
 	@AfterEach
@@ -115,7 +116,6 @@ class DeleteReadChaptersUseCaseTest {
 		assertEquals(1, deletedCount)
 		coVerify { localContentRepository.deleteChapters(manga, setOf(1L)) }
 		coVerify(exactly = 0) { mangaRepositoryFactory.create(any()) }
-		coVerify(exactly = 0) { localContentRepository.getRemoteContent(any()) }
 	}
 
 	@Test


### PR DESCRIPTION
This pull request introduces improvements to reading progress handling, chapter navigation, and local chapter management. The main focus is on ensuring that when a user completes a chapter, the application correctly advances to the next chapter (if available), and that local chapters are properly recognized and their pages are reloaded from local storage when necessary. Additionally, the download worker is enhanced to better handle temporary files and support downloading pages from ZIP sources.

**Reading Progress and Chapter Navigation:**

- Updated logic in `DetailsViewModel`, `ReadButtonDelegate`, and `HistoryInfo` to automatically advance to the next chapter when the current chapter is completed, ensuring smoother reading progression. [[1]](diffhunk://#diff-d6eab077945cd32567c7203f2c8a9819bfc162d816f80845f436bdaeb9b4786eL2883-R2908) [[2]](diffhunk://#diff-c609c9d79b8cb8c2fbc367cfb9c16c92cf40f05c9cef99226a3ffc90b476e6f6L102-R119) [[3]](diffhunk://#diff-c7d9111b1d4aadaa2624a3e6bdef8a125f235d6155e40b08acaad46ad29b0c90L45-R60)

**Download Worker Enhancements:**

- Improved temporary file handling during downloads: pages are now saved to a chapter-specific temp directory, with better file naming and cleanup after successful downloads. [[1]](diffhunk://#diff-0f6b2b85b211382cd13a63c798adc8d258ce4d21aa7e1cd377a61bb3082b43a8R846-R850) [[2]](diffhunk://#diff-0f6b2b85b211382cd13a63c798adc8d258ce4d21aa7e1cd377a61bb3082b43a8R865-L871) [[3]](diffhunk://#diff-0f6b2b85b211382cd13a63c798adc8d258ce4d21aa7e1cd377a61bb3082b43a8R920)
- Added support for downloading pages directly from ZIP archives by extracting the relevant entry, increasing compatibility with different content sources.

**Local Chapter Management:**

- Added a method `isChapterLocal` to `ChaptersLoader` to check if a chapter uses a local page source, and updated `ReaderViewModel` to reload chapter pages from local storage if any remote pages are detected for a local chapter. [[1]](diffhunk://#diff-59cc9d734cad9da186ad8e96832b6d13d96fde7ea7130d22f923fcc11a02655fR100-R103) [[2]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19R797-R815)