### PR TITLE
Fixed Madara theme using websites not displaying all chapters

### DIFF
--- a/app/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/app/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -103,6 +103,12 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     override suspend fun getPopularManga(page: Int): MangasPage {
+        if (
+            overridesMethod("fetchPopularManga", Integer.TYPE) &&
+            !overridesMethod("popularMangaRequest", Integer.TYPE)
+        ) {
+            return fetchPopularManga(page).toBlocking().first()
+        }
         return try {
             val request = tagRequest(popularMangaRequest(page))
             client.newCall(request).awaitSuccess().use { response ->
@@ -134,6 +140,12 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+        if (
+            overridesMethod("fetchSearchManga", Integer.TYPE, String::class.java, FilterList::class.java) &&
+            !overridesMethod("searchMangaRequest", Integer.TYPE, String::class.java, FilterList::class.java)
+        ) {
+            return fetchSearchManga(page, query, filters).toBlocking().first()
+        }
         return try {
             val request = tagRequest(searchMangaRequest(page, query, filters))
             val response = client.newCall(request).awaitSuccess()
@@ -200,6 +212,12 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     override suspend fun getLatestUpdates(page: Int): MangasPage {
+        if (
+            overridesMethod("fetchLatestUpdates", Integer.TYPE) &&
+            !overridesMethod("latestUpdatesRequest", Integer.TYPE)
+        ) {
+            return fetchLatestUpdates(page).toBlocking().first()
+        }
         return try {
             val request = tagRequest(latestUpdatesRequest(page))
             client.newCall(request).awaitSuccess().use { response ->
@@ -220,6 +238,12 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     override suspend fun getMangaDetails(manga: SManga): SManga {
+        if (
+            overridesMethod("fetchMangaDetails", SManga::class.java) &&
+            !overridesMethod("mangaDetailsRequest", SManga::class.java)
+        ) {
+            return fetchMangaDetails(manga).toBlocking().first()
+        }
         return try {
             val request = tagRequest(mangaDetailsRequest(manga))
             client.newCall(request).awaitSuccess().use { response ->
@@ -249,6 +273,9 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     override suspend fun getChapterList(manga: SManga): List<SChapter> {
+        if (overridesMethod("fetchChapterList", SManga::class.java)) {
+            return fetchChapterList(manga).toBlocking().first()
+        }
         return try {
             val request = tagRequest(chapterListRequest(manga))
             client.newCall(request).awaitSuccess().use { response ->
@@ -324,6 +351,12 @@ abstract class HttpSource : CatalogueSource {
 
     @Suppress("DEPRECATION")
     open suspend fun getImageUrl(page: Page): String {
+        if (
+            overridesMethod("fetchImageUrl", Page::class.java) &&
+            !overridesMethod("imageUrlRequest", Page::class.java)
+        ) {
+            return fetchImageUrl(page).toBlocking().first()
+        }
         return try {
             val request = tagRequest(imageUrlRequest(page))
             client.newCall(request).awaitSuccess().use { response ->

--- a/app/src/test/kotlin/org/skepsun/kototoro/mihon/TachiyomiXSourceCompatibilityTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/mihon/TachiyomiXSourceCompatibilityTest.kt
@@ -114,6 +114,15 @@ class TachiyomiXSourceCompatibilityTest {
 		assertEquals(listOf("https://images.example.org/1.jpg"), pages.map { it.imageUrl })
 	}
 
+	@Test
+	fun `HttpSource suspend chapter list uses fetchChapterList when both request helper and fetch are overridden`() = runTest {
+		val source = LegacyFetchWithRequestHttpSource()
+
+		val chapters = source.getChapterList(manga("/manga", "Manga"))
+
+		assertEquals(listOf("Legacy Custom Chapter"), chapters.map { it.name })
+	}
+
 	private class LegacyCatalogueSource : CatalogueSource {
 		override val id: Long = 1L
 		override val name: String = "Legacy"
@@ -220,6 +229,35 @@ class TachiyomiXSourceCompatibilityTest {
 		override fun latestUpdatesParse(response: Response): MangasPage = unused()
 		override fun mangaDetailsParse(response: Response): SManga = unused()
 		override fun chapterListParse(response: Response): List<SChapter> = unused()
+		override fun pageListParse(response: Response): List<Page> = unused()
+		override fun imageUrlParse(response: Response): String = unused()
+	}
+
+	private class LegacyFetchWithRequestHttpSource : HttpSource() {
+		override val baseUrl: String = "https://example.org"
+		override val lang: String = "en"
+		override val name: String = "Legacy Fetch With Request"
+		override val supportsLatest: Boolean = false
+
+		override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+			return Observable.just(listOf(chapter("/legacy-custom", "Legacy Custom Chapter")))
+		}
+
+		override fun chapterListRequest(manga: SManga): Request {
+			return Request.Builder().url("$baseUrl/manga/path").build()
+		}
+
+		override fun chapterListParse(response: Response): List<SChapter> {
+			return listOf(chapter("/parsed", "Parsed Chapter"))
+		}
+
+		override fun popularMangaRequest(page: Int): Request = unused()
+		override fun popularMangaParse(response: Response): MangasPage = unused()
+		override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = unused()
+		override fun searchMangaParse(response: Response): MangasPage = unused()
+		override fun latestUpdatesRequest(page: Int): Request = unused()
+		override fun latestUpdatesParse(response: Response): MangasPage = unused()
+		override fun mangaDetailsParse(response: Response): SManga = unused()
 		override fun pageListParse(response: Response): List<Page> = unused()
 		override fun imageUrlParse(response: Response): String = unused()
 	}


### PR DESCRIPTION
This pull request improves the compatibility logic in the `HttpSource` class, ensuring that when both legacy "fetch" and "request helper" methods are overridden, the correct method is called. It also adds a test to verify this behavior for chapter lists. The main focus is on better handling of method overrides to maintain backward compatibility with different source implementations.

Key changes include:

### Compatibility logic improvements in `HttpSource`:

* Updated all main suspend functions in `HttpSource` (such as `getPopularManga`, `getSearchManga`, `getLatestUpdates`, `getMangaDetails`, `getChapterList`, and `getImageUrl`) to check whether the legacy "fetch" method is overridden, and only use it if the corresponding "request helper" method is not overridden. This ensures that the correct override is used depending on the source implementation. [[1]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R106-R111) [[2]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R143-R148) [[3]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R215-R220) [[4]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R241-R246) [[5]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R276-R278) [[6]](diffhunk://#diff-19b165074f8e7258db71d2971d739370645228b7c6afae29ad3ca1bc718f0cf6R354-R359)

### Testing and verification:

* Added a new test in `TachiyomiXSourceCompatibilityTest` to verify that `getChapterList` uses `fetchChapterList` when both `fetchChapterList` and `chapterListRequest` are overridden.
* Introduced a new test helper class, `LegacyFetchWithRequestHttpSource`, which overrides both methods and returns different results, allowing the test to confirm the correct method is called.