### PR TITLE
Fix chapter numbering and enhance content fetching mechanism

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/mihon/MihonMangaRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/mihon/MihonMangaRepository.kt
@@ -187,7 +187,7 @@ class MihonMangaRepository(
         val chapters = rawChapters.asReversed()
             .mapIndexed { index, sChapter ->
                 // 如果插件有提供合法的编号则保留，否则使用我们在反转列表中的索引位置。
-                val chapterNumber = if (sChapter.chapter_number > 0) {
+                val chapterNumber = if (sChapter.chapter_number >= 0) {
                     sChapter.chapter_number
                 } else {
                     (index + 1).toFloat()

--- a/app/src/main/kotlin/org/skepsun/kototoro/mihon/compat/MihonRequestContext.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/mihon/compat/MihonRequestContext.kt
@@ -1,5 +1,7 @@
 package org.skepsun.kototoro.mihon.compat
 
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.withContext
 import org.skepsun.kototoro.parsers.model.ContentSource
 
 /**
@@ -26,16 +28,8 @@ object MihonRequestContext {
     }
 
     suspend fun <T> withSource(source: ContentSource, block: suspend () -> T): T {
-        val previous = currentSource.get()
-        currentSource.set(source)
-        return try {
+        return withContext(currentSource.asContextElement(source)) {
             block()
-        } finally {
-            if (previous == null) {
-                currentSource.remove()
-            } else {
-                currentSource.set(previous)
-            }
         }
     }
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/CheckNewChaptersUseCase.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/CheckNewChaptersUseCase.kt
@@ -110,7 +110,7 @@ class CheckNewChaptersUseCase @Inject constructor(
 
 	private suspend fun invokeImpl(track: ContentTracking): MangaUpdates = runCatchingCancellable {
 		val executionSeed = repository.getExecutionTrackingContent(track)
-		val details = getFullContent(executionSeed)
+		val details = getFullContent(executionSeed, forceFetch = true)
 		compare(track, details, getBranch(details, track.lastChapterId))
 	}.getOrElse { error ->
 		MangaUpdates.Failure(
@@ -134,13 +134,13 @@ class CheckNewChaptersUseCase @Inject constructor(
 		return manga.getPreferredBranch(null)
 	}
 
-	private suspend fun getFullContent(manga: Content): Content = when {
+	private suspend fun getFullContent(manga: Content, forceFetch: Boolean = false): Content = when {
 		manga.isLocal -> {
 			val remote = localContentRepository.getRemoteContent(manga)
 			if (remote != null) fetchDetails(remote) else manga
 		}
 
-		manga.chapters.isNullOrEmpty() -> fetchDetails(manga)
+		forceFetch || manga.chapters.isNullOrEmpty() -> fetchDetails(manga)
 		else -> manga
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to coroutine context management and enhances the logic for fetching manga details, particularly in the context of chapter checking and repository behavior. The most significant changes are grouped below:

**Coroutine Context Management:**

* Refactored `MihonRequestContext.withSource` to use `withContext` and `asContextElement` for safer and more idiomatic coroutine context propagation, eliminating manual thread-local management. [[1]](diffhunk://#diff-622ce03bb55d1bb3e727250fc7a5fe905bd1e1715ca0d59f1e3dd52ff8b74e61R3-R4) [[2]](diffhunk://#diff-622ce03bb55d1bb3e727250fc7a5fe905bd1e1715ca0d59f1e3dd52ff8b74e61L29-L38)

**Manga Detail Fetching Logic:**

* Updated `CheckNewChaptersUseCase` to always force-fetch content details when checking for new chapters, ensuring the latest data is retrieved.
* Modified `getFullContent` to accept a `forceFetch` parameter, allowing callers to explicitly request fresh data even if chapters are already present.

**Chapter Numbering Logic:**

* Adjusted chapter numbering in `MihonMangaRepository` so that a chapter number of zero is now considered valid and preserved, rather than replaced with an index-based fallback.