### PR TITLE
Add configurable feed limit and time-based unread tracking

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/db/dao/TrackLogsDao.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/db/dao/TrackLogsDao.kt
@@ -28,6 +28,9 @@ abstract class TrackLogsDao : MangaQueryBuilder.ConditionCallback {
 	@Query("SELECT COUNT(*) FROM track_logs WHERE unread = 1")
 	abstract fun observeUnreadCount(): Flow<Int>
 
+	@Query("SELECT COUNT(*) FROM track_logs WHERE unread = 1 AND created_at > :lastOpenTime")
+	abstract fun observeUnreadCount(lastOpenTime: Long): Flow<Int>
+
 	@Query("SELECT * FROM track_logs ORDER BY created_at DESC")
 	abstract suspend fun dump(): List<TrackLogEntity>
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
@@ -809,6 +809,14 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		get() = prefs.getBoolean(KEY_SHOW_ALL_UPDATES, false)
 		set(value) = prefs.edit { putBoolean(KEY_SHOW_ALL_UPDATES, value) }
 
+	var feedLimit: Int
+		get() = prefs.getInt(KEY_FEED_LIMIT, 200)
+		set(value) = prefs.edit { putInt(KEY_FEED_LIMIT, value) }
+
+	var feedLastOpenTime: Long
+		get() = prefs.getLong(KEY_FEED_LAST_OPEN_TIME, 0L)
+		set(value) = prefs.edit { putLong(KEY_FEED_LAST_OPEN_TIME, value) }
+
 	var progressIndicatorMode: ProgressIndicatorMode
 		get() = prefs.getEnumValue(KEY_PROGRESS_INDICATORS, ProgressIndicatorMode.PERCENT_READ)
 		set(value) = prefs.edit { putEnumValue(KEY_PROGRESS_INDICATORS, value) }
@@ -2434,6 +2442,8 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		const val KEY_STATS_ENABLED = "stats_on"
 		const val KEY_FEED_HEADER = "feed_header"
 		const val KEY_SHOW_ALL_UPDATES = "show_all_updates"
+		const val KEY_FEED_LIMIT = "feed_limit"
+		const val KEY_FEED_LAST_OPEN_TIME = "feed_last_open_time"
 		const val KEY_SEARCH_SUGGESTION_TYPES = "search_suggest_types"
 		const val KEY_SOURCES_VERSION = "sources_version"
 		const val KEY_SOURCES_ENABLED_ALL = "sources_enabled_all"

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
@@ -52,6 +52,7 @@ import org.skepsun.kototoro.details.ui.model.EntityChapterSourceInfo
 import org.skepsun.kototoro.details.ui.model.toListItem
 import org.skepsun.kototoro.details.ui.model.LinkedTrackingItemUiModel
 import org.skepsun.kototoro.bookmarks.domain.BookmarksRepository
+import org.skepsun.kototoro.tracker.domain.TrackingRepository
 import org.skepsun.kototoro.core.model.ContentSource
 import org.skepsun.kototoro.core.model.ContentSourceInfo
 import org.skepsun.kototoro.core.model.getContentType
@@ -498,6 +499,7 @@ class DetailsViewModel @Inject constructor(
 	private val entityGraphRepository: org.skepsun.kototoro.entitygraph.data.EntityGraphRepository,
 	private val trackingSiteDiscoveryService: org.skepsun.kototoro.tracking.discovery.domain.TrackingSiteDiscoveryService,
 	private val sourceTypeIdentifier: SourceTypeIdentifier,
+	private val trackingRepository: TrackingRepository,
 	private val workResolver: org.skepsun.kototoro.work.domain.WorkResolver,
 ) : ChaptersPagesViewModel(
 	settings = settings,
@@ -5284,6 +5286,7 @@ class DetailsViewModel @Inject constructor(
 				)
 				baseLoadedDetails = finalDetails
 				syncDisplayedState()
+				trackingRepository.clearReadUpdates(finalDetails.id)
 				val localEntityId = entityGraphRepository.findEntityByBinding("0", finalDetails.id.toString())?.id
 					?: entityGraphRepository.findEntityByBinding("local_manga", finalDetails.id.toString())?.id
 				if (localEntityId != null && !isTrackingOriginSelectionPinned()) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/list/domain/ContentListMapper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/list/domain/ContentListMapper.kt
@@ -33,6 +33,7 @@ import org.skepsun.kototoro.tracking.discovery.domain.TrackingSiteItemDetails
 import org.skepsun.kototoro.tracker.domain.TrackingRepository
 import org.skepsun.kototoro.tracker.domain.model.TrackingLogItem
 import org.skepsun.kototoro.tracker.ui.feed.model.FeedItem
+import org.skepsun.kototoro.core.db.MangaDatabase
 import javax.inject.Inject
 
 @Reusable
@@ -45,6 +46,7 @@ class ContentListMapper @Inject constructor(
 	private val localContentIndex: LocalContentIndex,
 	private val dataRepository: ContentDataRepository,
 	private val trackingSiteCacheRepository: TrackingSiteCacheRepository,
+	private val db: MangaDatabase,
 ) {
 
 	data class ListModelRequest(
@@ -221,6 +223,9 @@ class ContentListMapper @Inject constructor(
 		val manualOverrides = dataRepository.getOverrides()
 		val metadataSelections = dataRepository.getMetadataSourceSelections(mangaIds)
 		val trackingDetailsCache = HashMap<Pair<Int, Long>, TrackingSiteItemDetails?>()
+		val chapterCounts = db.getChaptersDao().findAllByMangaIds(mangaIds)
+			.groupBy { it.mangaId }
+			.mapValues { it.value.size }
 		return logItems.map { logItem ->
 			FeedItem(
 				id = logItem.id,
@@ -235,6 +240,7 @@ class ContentListMapper @Inject constructor(
 				count = logItem.count ?: logItem.chapters.size,
 				manga = logItem.manga,
 				isNew = logItem.isNew,
+				totalChapters = chapterCounts[logItem.manga.id] ?: 0,
 			)
 		}
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/AppNavGraph.kt
@@ -1217,6 +1217,7 @@ internal fun FeedTopLevelRouteContent(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.update() },
             onLoadMore = { viewModel.requestMoreItems() },
+            onFeedOpened = { viewModel.markFeedAsOpened() },
             onFeedItemClick = { item, _ ->
                 viewModel.onItemClick(item)
                 val content = item.toContentWithOverride()

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.view.MotionEvent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.material3.Slider
+import kotlin.math.roundToInt
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -715,6 +717,9 @@ fun KototoroApp(
     val showAllUpdates by appSettings.observeAsState(keys = arrayOf(org.skepsun.kototoro.core.prefs.AppSettings.KEY_SHOW_ALL_UPDATES)) {
         showAllUpdates
     }
+    val feedLimit by appSettings.observeAsState(keys = arrayOf(org.skepsun.kototoro.core.prefs.AppSettings.KEY_FEED_LIMIT)) {
+        feedLimit
+    }
     val sortOrders = layeredTopBarOverrideState?.sortOrders?.takeIf { it.isNotEmpty() } ?: fallbackFavoritesSortOrders
     val selectedSortOrder = layeredTopBarOverrideState?.selectedSortOrder ?: if (isFavoritesRoute) {
         globalFavoritesSortOrder
@@ -731,6 +736,8 @@ fun KototoroApp(
             FeedDisplayOptionsContent(
                 showAllUpdates = showAllUpdates,
                 onShowAllUpdatesChanged = { appSettings.showAllUpdates = it },
+                feedLimit = feedLimit,
+                onFeedLimitChanged = { appSettings.feedLimit = it },
                 onFeedRefresh = {
                     onFeedRefresh()
                     dismiss()
@@ -1329,8 +1336,12 @@ private fun BoxScope.MainTopChrome(
 private fun FeedDisplayOptionsContent(
     showAllUpdates: Boolean,
     onShowAllUpdatesChanged: (Boolean) -> Unit,
+    feedLimit: Int,
+    onFeedLimitChanged: (Int) -> Unit,
     onFeedRefresh: () -> Unit,
 ) {
+    val jumps = remember { listOf(50, 100, 200, 500, 1000, 2000) }
+    val limitIndex = remember(feedLimit) { jumps.indexOf(feedLimit).coerceAtLeast(0) }
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -1350,6 +1361,37 @@ private fun FeedDisplayOptionsContent(
             Switch(
                 checked = showAllUpdates,
                 onCheckedChange = onShowAllUpdatesChanged,
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.feed_visible_entries),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = feedLimit.toString(),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+            Slider(
+                value = limitIndex.toFloat(),
+                onValueChange = { index ->
+                    onFeedLimitChanged(jumps[index.roundToInt()])
+                },
+                valueRange = 0f..(jumps.size - 1).toFloat(),
+                steps = jumps.size - 2,
+                modifier = Modifier.fillMaxWidth()
             )
         }
         AnimatedVisibility(visible = showAllUpdates) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/data/TracksDao.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/data/TracksDao.kt
@@ -45,6 +45,9 @@ abstract class TracksDao : MangaQueryBuilder.ConditionCallback {
 	@Query("SELECT COUNT(*) FROM tracks WHERE chapters_new > 0")
 	abstract fun observeUpdateContentCount(): Flow<Int>
 
+	@Query("SELECT COUNT(*) FROM tracks WHERE chapters_new > 0 AND last_check_time > :lastOpenTime")
+	abstract fun observeUpdateContentCount(lastOpenTime: Long): Flow<Int>
+
 	@Query("SELECT IFNULL(chapters_new, 0) FROM tracks WHERE manga_id = :mangaId LIMIT 1")
 	abstract fun observeNewChapters(mangaId: Long): Flow<Int>
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
@@ -22,6 +22,7 @@ import org.skepsun.kototoro.core.db.entity.toEntity
 import org.skepsun.kototoro.core.db.entity.toEntities
 import org.skepsun.kototoro.core.parser.ContentDataRepository
 import org.skepsun.kototoro.core.prefs.AppSettings
+import org.skepsun.kototoro.core.prefs.observeAsFlow
 import org.skepsun.kototoro.core.util.ext.mapItems
 import org.skepsun.kototoro.core.util.ext.toInstantOrNull
 import org.skepsun.kototoro.details.domain.ProgressUpdateUseCase
@@ -103,11 +104,14 @@ class TrackingRepository @Inject constructor(
 	}
 
 	fun observeUnreadUpdatesCount(): Flow<Int> {
-		return combine(
-			db.getTrackLogsDao().observeUnreadCount(),
-			db.getTracksDao().observeUpdateContentCount(),
-		) { unreadLogs, updatedContent ->
-			maxOf(unreadLogs, updatedContent)
+		val lastOpenTimeFlow = settings.observeAsFlow(AppSettings.KEY_FEED_LAST_OPEN_TIME) { feedLastOpenTime }
+		return lastOpenTimeFlow.flatMapLatest { lastOpenTime ->
+			combine(
+				db.getTrackLogsDao().observeUnreadCount(lastOpenTime),
+				db.getTracksDao().observeUpdateContentCount(lastOpenTime),
+			) { unreadLogs, updatedContent ->
+				maxOf(unreadLogs, updatedContent)
+			}
 		}
 	}
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/FeedViewModel.kt
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 private const val PAGE_SIZE = 20
-private const val UPDATED_CONTENT_LOOKAHEAD_SIZE = 200
+private const val UPDATED_CONTENT_LOOKAHEAD_SIZE = 2000
 
 @HiltViewModel
 class FeedViewModel @Inject constructor(
@@ -89,9 +89,23 @@ class FeedViewModel @Inject constructor(
 		val preset: org.skepsun.kototoro.explore.data.SourcePreset?,
 	)
 
-	private val limit = MutableStateFlow(PAGE_SIZE)
+	private val feedLimitFlow = settings.observeAsStateFlow(
+		scope = viewModelScope + Dispatchers.Default,
+		key = AppSettings.KEY_FEED_LIMIT,
+		valueProducer = { feedLimit },
+	)
+
+	private val limit = MutableStateFlow(settings.feedLimit)
 	private val isReady = AtomicBoolean(false)
 	private val selectedCategoryId = MutableStateFlow(NO_ID)
+
+	init {
+		launchJob(Dispatchers.Default) {
+			feedLimitFlow.collect { newLimit ->
+				limit.value = newLimit
+			}
+		}
+	}
 
 	val categories = favouritesRepository.observeCategoriesForLibrary()
 		.map { listOf(FavouriteCategory(id = NO_ID, title = "", sortKey = Int.MIN_VALUE, order = org.skepsun.kototoro.list.domain.ListSortOrder.NEWEST, createdAt = java.time.Instant.EPOCH, isTrackingEnabled = false, isVisibleInLibrary = true)) + it }
@@ -299,8 +313,12 @@ class FeedViewModel @Inject constructor(
 
 	fun requestMoreItems() {
 		if (isReady.compareAndSet(true, false)) {
-			limit.value += PAGE_SIZE
+			limit.value += 50
 		}
+	}
+
+	fun markFeedAsOpened() {
+		settings.feedLastOpenTime = System.currentTimeMillis()
 	}
 
 	fun update() {

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedItemCard.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedItemCard.kt
@@ -142,12 +142,21 @@ fun FeedItemCard(
 					overflow = TextOverflow.Ellipsis,
 				)
 			}
-			Text(
-				text = pluralStringResource(
+			val chapterText = if (item.count > 0) {
+				pluralStringResource(
 					id = R.plurals.new_chapters,
 					count = item.count,
 					item.count,
-				),
+				)
+			} else {
+				pluralStringResource(
+					id = R.plurals.old_chapters_in_total,
+					count = item.totalChapters,
+					item.totalChapters,
+				)
+			}
+			Text(
+				text = chapterText,
 				style = MaterialTheme.typography.bodySmall,
 				color = MaterialTheme.colorScheme.onSurfaceVariant,
 				maxLines = 1,

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/compose/FeedScreen.kt
@@ -66,6 +66,7 @@ fun FeedScreen(
 	isRefreshing: Boolean,
 	onRefresh: () -> Unit,
 	onLoadMore: () -> Unit,
+	onFeedOpened: () -> Unit = {},
 	onFeedItemClick: (FeedItem, Rect?) -> Unit,
 	onUpdatedContentItemClick: (UpdatedContentHeaderItem, Rect?) -> Unit,
 	onUpdatedContentMoreClick: (UpdatedContentHeader) -> Unit,
@@ -80,6 +81,10 @@ fun FeedScreen(
 		LazyListState()
 	}
 	val context = LocalContext.current
+
+	LaunchedEffect(Unit) {
+		onFeedOpened()
+	}
 	val density = LocalDensity.current
 	val settings = remember(context.applicationContext) { AppSettings(context.applicationContext) }
 	val carouselPrefs by settings.observeAsState(

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/model/FeedItem.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/ui/feed/model/FeedItem.kt
@@ -15,6 +15,7 @@ data class FeedItem(
 	val manga: Content,
 	val count: Int,
 	val isNew: Boolean,
+	val totalChapters: Int = 0,
 ) : ListModel {
 
 	val imageUrl: String?

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -8,6 +8,10 @@
 		<item quantity="one">%1$d new chapter</item>
 		<item quantity="other">%1$d new chapters</item>
 	</plurals>
+	<plurals name="old_chapters_in_total">
+		<item quantity="one">%1$d old chapter in total</item>
+		<item quantity="other">%1$d old chapters in total</item>
+	</plurals>
 	<plurals name="home_updates_new_chapters">
 		<item quantity="one">%1$d new chapter</item>
 		<item quantity="other">%1$d new chapters</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="clear_updates_feed">Clear updates feed</string>
     <string name="updates_feed_cleared">Cleared</string>
     <string name="show_all_updates">Show all updates</string>
+    <string name="feed_visible_entries">Visible entries limit</string>
     <string name="feed_behavior_description">Default shows new unread chapters only.\n\nWhen enabled, the feed shows cached tracked entries with up to 10 chapters per item. Use Trigger Update to refresh tracked favorites.</string>
     <string name="trigger_update_now">Trigger Update</string>
     <string name="rotate_screen">Rotate screen</string>


### PR DESCRIPTION
Introduce a slider UI in feed display options to control the visible entries limit (50-2000 items). Implement time-based filtering of unread updates by tracking the last time the feed was opened, so the unread badge only counts new items since then. Display total chapter count when feed items have no new chapters. Changes include:

- New feed preferences: feedLimit and feedLastOpenTime
- DAO queries with time-based filtering
- FeedViewModel reactive updates to limit changes
- UI slider component for feed limit selection
- Total chapter display logic in FeedItemCard