### PR TITLE
Fix local reader state handling

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ChaptersMapper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ChaptersMapper.kt
@@ -100,10 +100,10 @@ fun ContentDetails.mapChapters(
 			}
 			val local = localById ?: localByUrl
 			val finalChapter = local ?: chapter
-			val isUnread = if (currentChapter != null) {
-				chapter.isAfter(currentChapter)
-			} else {
-				true
+			val isUnread = when {
+				currentChapterId == Long.MAX_VALUE -> false
+				currentChapter != null -> chapter.isAfter(currentChapter)
+				else -> true
 			}
 			
 			result += finalChapter.toListItem(

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
@@ -2917,7 +2917,11 @@ class DetailsViewModel @Inject constructor(
 						scroll = 0,
 					)
 				} else {
-					ReaderState(h.copy(chapterId = chapter.id))
+					ReaderState(
+						chapterId = Long.MAX_VALUE,
+						page = 0,
+						scroll = 0,
+					)
 				}
 			} else {
 				ReaderState(h.copy(chapterId = chapter.id))
@@ -5463,6 +5467,12 @@ class DetailsViewModel @Inject constructor(
 				item
 			}
 		}
+	}
+
+	override suspend fun onDownloadComplete(downloadedContent: LocalContent?) {
+		super.onDownloadComplete(downloadedContent)
+		downloadedContent ?: return
+		baseLoadedDetails = interactor.updateLocal(baseLoadedDetails, downloadedContent)
 	}
 
 	fun translateTitleAndDescription(forceRefresh: Boolean = false) {

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
@@ -115,7 +115,11 @@ internal fun openDetailsReader(
 							scroll = 0,
 						)
 					} else {
-						ReaderState(history.copy(chapterId = matchedChapter.id))
+						ReaderState(
+							chapterId = matchedChapter.id,
+							page = 0,
+							scroll = 0,
+						)
 					}
 				} else {
 					ReaderState(history.copy(chapterId = matchedChapter.id))

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/pager/ChaptersPagesViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/pager/ChaptersPagesViewModel.kt
@@ -479,7 +479,7 @@ abstract class ChaptersPagesViewModel(
 
 
 
-	private suspend fun onDownloadComplete(downloadedContent: LocalContent?) {
+	protected open suspend fun onDownloadComplete(downloadedContent: LocalContent?) {
 		downloadedContent ?: return
 		mangaDetails.update {
 			interactor.updateLocal(it, downloadedContent)


### PR DESCRIPTION
This pull request refactors how unread chapters and reader state are managed, and improves the handling of download completion updates. The changes ensure more consistent state management and better update of local content after downloads.

**Reader state and unread chapter logic:**

* Updated the logic for determining if a chapter is unread in `ChaptersMapper.kt` to explicitly check for a special `currentChapterId` value (`Long.MAX_VALUE`) and handle it as "read".
* Standardized the creation of `ReaderState` objects in both `DetailsViewModel.kt` and `ReadButtonDelegate.kt` to always initialize `page` and `scroll` to `0`, ensuring consistent reader behavior. [[1]](diffhunk://#diff-d6eab077945cd32567c7203f2c8a9819bfc162d816f80845f436bdaeb9b4786eL2920-R2924) [[2]](diffhunk://#diff-c609c9d79b8cb8c2fbc367cfb9c16c92cf40f05c9cef99226a3ffc90b476e6f6L118-R122)

**Download completion and local content updates:**

* Changed `onDownloadComplete` in `ChaptersPagesViewModel.kt` from private to protected and open, allowing subclasses to override it.
* Overrode `onDownloadComplete` in `DetailsViewModel.kt` to update `baseLoadedDetails` with the latest local content, ensuring UI reflects new downloads.