### PR TITLE
Fix tracker unread state and chapter counts

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/db/dao/TrackLogsDao.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/db/dao/TrackLogsDao.kt
@@ -60,6 +60,9 @@ abstract class TrackLogsDao : MangaQueryBuilder.ConditionCallback {
 	@Query("UPDATE track_logs SET unread = 0 WHERE owner_id = :ownerId AND unread = 1")
 	abstract suspend fun markUnreadAsReadByOwner(ownerId: Long)
 
+	@Query("SELECT DISTINCT manga_id FROM track_logs WHERE unread = 1 AND manga_id IN (:mangaIds)")
+	abstract suspend fun findUnreadMangaIds(mangaIds: List<Long>): List<Long>
+
 	@Query("SELECT * FROM track_logs WHERE id = :id LIMIT 1")
 	abstract suspend fun find(id: Long): TrackLogEntity?
 

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingLogItemMapper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingLogItemMapper.kt
@@ -12,6 +12,7 @@ object TrackingLogItemMapper {
 	fun fromAllTrackedContent(
 		tracks: List<ContentTracking>,
 		chapters: List<ChapterEntity>,
+		unreadMangaIds: Set<Long>? = null,
 	): List<TrackingLogItem> {
 		if (tracks.isEmpty()) {
 			return emptyList()
@@ -30,7 +31,11 @@ object TrackingLogItemMapper {
 				manga = track.manga,
 				chapters = chapterTitles,
 				createdAt = track.lastChapterDate ?: track.lastCheck ?: Instant.EPOCH,
-				isNew = track.newChapters > 0,
+				isNew = if (unreadMangaIds != null) {
+					track.newChapters > 0 && track.manga.id in unreadMangaIds
+				} else {
+					track.newChapters > 0
+				},
 				count = track.newChapters,
 			)
 		}

--- a/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/tracker/domain/TrackingRepository.kt
@@ -298,7 +298,14 @@ class TrackingRepository @Inject constructor(
 
 	suspend fun clearReadUpdates(mangaId: Long) = db.withTransaction {
 		for (anchorMangaId in resolveTrackAnchorMangaIdsForRead(mangaId)) {
-			clearTrackUpdates(anchorMangaId)
+			markTrackLogsAsRead(anchorMangaId)
+		}
+	}
+
+	private suspend fun markTrackLogsAsRead(anchorMangaId: Long) {
+		val track = db.getTracksDao().find(anchorMangaId)
+		track?.let {
+			db.getTrackLogsDao().markUnreadAsReadByOwner(it.ownerId)
 		}
 	}
 
@@ -371,7 +378,15 @@ class TrackingRepository @Inject constructor(
 				mangaId = anchorMangaId,
 				entityId = entityId,
 				lastChapterId = updates.manga.getChapters(updates.branch).lastOrNull()?.id ?: NO_ID,
-				newChapters = if (updates.isValid) newChapters + updates.newChapters.size else 0,
+				newChapters = if (updates.isValid) {
+					if (updates.newChapters.isNotEmpty()) {
+						updates.newChapters.size
+					} else {
+						newChapters
+					}
+				} else {
+					0
+				},
 				lastCheckTime = System.currentTimeMillis(),
 				lastChapterDate = updates.lastChapterDate().ifZero { lastChapterDate },
 				lastResult = if (updates.isNotEmpty()) TrackEntity.RESULT_HAS_UPDATE else TrackEntity.RESULT_NO_UPDATE,
@@ -525,7 +540,8 @@ class TrackingRepository @Inject constructor(
 		}
 		val chapters = db.getChaptersDao()
 			.findAllByMangaIds(tracks.map { it.manga.id })
-		return TrackingLogItemMapper.fromAllTrackedContent(tracks, chapters)
+		val unreadMangaIds = db.getTrackLogsDao().findUnreadMangaIds(tracks.map { it.manga.id }).toSet()
+		return TrackingLogItemMapper.fromAllTrackedContent(tracks, chapters, unreadMangaIds)
 	}
 
 	private suspend fun buildFallbackContentByAnchorId(anchorIds: Collection<Long>): Map<Long, Content> {


### PR DESCRIPTION
Align tracking update indicators with unread log state instead of relying only on `newChapters`. The repository now marks track logs as read by owner when clearing updates, queries unread manga IDs for tracked content, and passes that into `TrackingLogItemMapper` so `isNew` only stays true for truly unread items.

Also adjusts track update persistence so `newChapters` is replaced by the latest detected count when new chapters exist, preserved when valid checks find none, and reset to 0 on invalid results, avoiding incorrect accumulation.