### PR TITLE
Main UI improv

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt
@@ -142,6 +142,10 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		get() = prefs.getBoolean(KEY_THEME_AMOLED, false)
 		set(value) = prefs.edit { putBoolean(KEY_THEME_AMOLED, value) }
 
+	var backgroundStyle: BackgroundStyle
+		get() = prefs.getEnumValue(KEY_BACKGROUND_STYLE, BackgroundStyle.DEFAULT)
+		set(value) = prefs.edit { putEnumValue(KEY_BACKGROUND_STYLE, value) }
+
 	var tabletUiMode: TabletUiMode
 		get() = prefs.getEnumValue(KEY_TABLET_UI_MODE, TabletUiMode.RELAXED)
 		set(value) = prefs.edit { putEnumValue(KEY_TABLET_UI_MODE, value) }
@@ -2106,6 +2110,7 @@ class AppSettings @Inject constructor(@ApplicationContext private val context: C
 		const val KEY_THEME = "theme"
 		const val KEY_COLOR_THEME = "color_theme"
 		const val KEY_THEME_AMOLED = "amoled_theme"
+		const val KEY_BACKGROUND_STYLE = "background_style"
 		const val KEY_MATERIAL_EXPRESSIVE_COMPONENTS = "material_expressive_components"
 		const val KEY_APP_FONT_PRESET = "app_font_preset"
 		const val KEY_EXPRESSIVE_APP_FONT_PRESET = "expressive_app_font_preset"

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/BackgroundStyle.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/prefs/BackgroundStyle.kt
@@ -1,0 +1,35 @@
+package org.skepsun.kototoro.core.prefs
+
+import androidx.annotation.Keep
+import androidx.annotation.StringRes
+import org.skepsun.kototoro.R
+import org.skepsun.kototoro.parsers.util.find
+
+@Keep
+enum class BackgroundStyle(
+	@StringRes val titleResId: Int,
+	@StringRes val summaryResId: Int,
+) {
+	DEFAULT(
+		titleResId = R.string.bg_style_default,
+		summaryResId = R.string.bg_style_default_summary,
+	),
+	DYNAMIC_ARTWORK_BLUR(
+		titleResId = R.string.bg_style_artwork_blur,
+		summaryResId = R.string.bg_style_artwork_blur_summary,
+	),
+	SYSTEM_DYNAMIC_TINT(
+		titleResId = R.string.bg_style_system_tint,
+		summaryResId = R.string.bg_style_system_tint_summary,
+	),
+	ELEVATED_CONTAINERS(
+		titleResId = R.string.bg_style_elevated_containers,
+		summaryResId = R.string.bg_style_elevated_containers_summary,
+	);
+
+	companion object {
+		fun safeValueOf(name: String): BackgroundStyle? {
+			return BackgroundStyle.entries.find(name)
+		}
+	}
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/GlassSurface.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/GlassSurface.kt
@@ -43,6 +43,8 @@ import org.skepsun.kototoro.core.prefs.AppSettings
 import org.skepsun.kototoro.core.prefs.observeAsState
 import org.skepsun.kototoro.core.prefs.resolvePreset
 import org.skepsun.kototoro.core.prefs.toFamily
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
+import org.skepsun.kototoro.core.ui.theme.LocalBackgroundStyle
 import org.skepsun.kototoro.core.ui.BaseActivityEntryPoint
 
 private const val GLASS_SURFACE_TAG = "GlassSurface"
@@ -227,8 +229,16 @@ fun GlassSurface(
             }
         }
     }
+    if (dialogSurface) {
+        ApplyDynamicArtworkBlurDialogStyle()
+    }
+    val backgroundStyle = LocalBackgroundStyle.current
     val surfaceColor = when {
-        dialogSurface -> glassColors.containerColor
+        dialogSurface -> if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            glassColors.containerColor.copy(alpha = 0.86f.coerceAtLeast(glassColors.containerColor.alpha))
+        } else {
+            glassColors.containerColor
+        }
         shouldUsePrototypeSurfaceFill -> runtimeChromeFillColor
         useRuntimeHaze && !dialogSurface -> Color.Transparent
         !useRuntimeHaze && glassPrefs.isGlassEffectEnabled && usesOfficialHazeMaterial -> {

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/KototoroDialogHelper.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/KototoroDialogHelper.kt
@@ -1,0 +1,54 @@
+package org.skepsun.kototoro.core.ui.glass
+
+import android.os.Build
+import android.view.View
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
+import org.skepsun.kototoro.core.ui.theme.LocalBackgroundStyle
+
+/**
+ * A composable side-effect utility that applies real-time native window blurring (FLAG_BLUR_BEHIND)
+ * and deep background dimming (`dimAmount = 0.70f`) to the host [DialogWindow] whenever
+ * [BackgroundStyle.DYNAMIC_ARTWORK_BLUR] is active.
+ *
+ * This ensures that when any [AlertDialog], [Dialog], or bottom sheet pops up over the screen,
+ * the underlying activity/settings content instantly blurs out smoothly, preventing visual overlap
+ * and keeping dialog text 100% sharp and readable.
+ */
+@Composable
+fun ApplyDynamicArtworkBlurDialogStyle() {
+    val backgroundStyle = LocalBackgroundStyle.current
+    val view = LocalView.current
+
+    if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+        SideEffect {
+            val window = findDialogWindow(view)
+            if (window != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+                    window.attributes = window.attributes.apply {
+                        blurBehindRadius = 60
+                    }
+                }
+                window.setDimAmount(0.70f)
+            }
+        }
+    }
+}
+
+private fun findDialogWindow(view: View): Window? {
+    var current: View? = view
+    while (current != null) {
+        if (current is DialogWindowProvider) {
+            return current.window
+        }
+        val parent = current.parent
+        current = if (parent is View) parent else null
+    }
+    return (view.context as? android.app.Dialog)?.window
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
@@ -31,7 +31,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
+
 val LocalMaterialExpressiveComponentsEnabled = staticCompositionLocalOf { false }
+val LocalBackgroundStyle = staticCompositionLocalOf { BackgroundStyle.DEFAULT }
 
 @Composable
 fun KototoroTheme(
@@ -52,8 +55,11 @@ fun KototoroTheme(
     val expressiveAppFontPreset by settings.observeAsState(AppSettings.KEY_EXPRESSIVE_APP_FONT_PRESET) {
         expressiveAppFontPreset
     }
-    val colorScheme = remember(context, darkTheme, dynamicColor) {
-        context.resolveComposeColorScheme(darkTheme)
+    val backgroundStyle by settings.observeAsState(AppSettings.KEY_BACKGROUND_STYLE) {
+        backgroundStyle
+    }
+    val colorScheme = remember(context, darkTheme, dynamicColor, backgroundStyle) {
+        context.resolveComposeColorScheme(darkTheme, backgroundStyle)
     }
     
     val radius = when {
@@ -86,7 +92,10 @@ fun KototoroTheme(
         )
     }
 
-    CompositionLocalProvider(LocalMaterialExpressiveComponentsEnabled provides expressiveComponents) {
+    CompositionLocalProvider(
+        LocalMaterialExpressiveComponentsEnabled provides expressiveComponents,
+        LocalBackgroundStyle provides backgroundStyle,
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             shapes = shapes,
@@ -154,6 +163,7 @@ private fun kototoroTypography(
 
 private fun android.content.Context.resolveComposeColorScheme(
     darkTheme: Boolean,
+    backgroundStyle: BackgroundStyle,
 ): ColorScheme {
     val background = themeColor(android.R.attr.colorBackground)
     val surface = themeColorByName("colorSurface", background)
@@ -200,11 +210,43 @@ private fun android.content.Context.resolveComposeColorScheme(
     )
 
     return if (darkTheme) {
-        val liftedSurfaceContainerLowest = common.surfaceContainerLowest.liftForDarkContrast(0.10f)
-        val liftedSurfaceContainerLow = common.surfaceContainerLow.liftForDarkContrast(0.14f)
-        val liftedSurfaceContainer = common.surfaceContainer.liftForDarkContrast(0.16f)
-        val liftedSurfaceContainerHigh = common.surfaceContainerHigh.liftForDarkContrast(0.18f)
-        val liftedSurfaceContainerHighest = common.surfaceContainerHighest.liftForDarkContrast(0.20f)
+        val baseBg = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(Color(0xFF0C0D0F), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color.Black
+            BackgroundStyle.DEFAULT -> Color.Black
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color.Black
+        }
+        val baseSurface = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(Color(0xFF111316), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF141414)
+            BackgroundStyle.DEFAULT -> Color.Black
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF0C0C0C)
+        }
+        val liftedSurfaceContainerLowest = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerLowest.liftForDarkContrast(0.10f), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF121212)
+            else -> common.surfaceContainerLowest.liftForDarkContrast(0.10f)
+        }
+        val liftedSurfaceContainerLow = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerLow.liftForDarkContrast(0.14f), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF161616)
+            else -> common.surfaceContainerLow.liftForDarkContrast(0.14f)
+        }
+        val liftedSurfaceContainer = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainer.liftForDarkContrast(0.16f), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF1E1E1E)
+            else -> common.surfaceContainer.liftForDarkContrast(0.16f)
+        }
+        val liftedSurfaceContainerHigh = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHigh.liftForDarkContrast(0.18f), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF242424)
+            else -> common.surfaceContainerHigh.liftForDarkContrast(0.18f)
+        }
+        val liftedSurfaceContainerHighest = when (backgroundStyle) {
+            BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHighest.liftForDarkContrast(0.20f), common.primary, 0.08f)
+            BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF2C2C2C)
+            else -> common.surfaceContainerHighest.liftForDarkContrast(0.20f)
+        }
 
         darkColorScheme(
             primary = common.primary,
@@ -220,9 +262,9 @@ private fun android.content.Context.resolveComposeColorScheme(
             onTertiary = common.onTertiary,
             tertiaryContainer = common.tertiaryContainer,
             onTertiaryContainer = common.onTertiaryContainer,
-            background = common.background,
+            background = baseBg,
             onBackground = common.onBackground,
-            surface = common.surface,
+            surface = baseSurface,
             onSurface = common.onSurface,
             surfaceVariant = common.surfaceVariant,
             onSurfaceVariant = common.onSurfaceVariant,

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
@@ -243,13 +243,13 @@ private fun android.content.Context.resolveComposeColorScheme(
         val liftedSurfaceContainerHigh = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHigh.liftForDarkContrast(0.18f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF242424)
-            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF202026).copy(alpha = 0.58f)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF202026).copy(alpha = 0.86f)
             else -> common.surfaceContainerHigh.liftForDarkContrast(0.18f)
         }
         val liftedSurfaceContainerHighest = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHighest.liftForDarkContrast(0.20f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF2C2C2C)
-            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF26262E).copy(alpha = 0.64f)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF26262E).copy(alpha = 0.90f)
             else -> common.surfaceContainerHighest.liftForDarkContrast(0.20f)
         }
         val liftedSurfaceVariant = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
@@ -271,6 +271,11 @@ private fun android.content.Context.resolveComposeColorScheme(
             common.secondaryContainer.copy(alpha = 0.55f)
         } else {
             common.secondaryContainer
+        }
+        val resolvedScrim = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            Color(0xCC000000)
+        } else {
+            Color.Black
         }
 
         darkColorScheme(
@@ -302,7 +307,7 @@ private fun android.content.Context.resolveComposeColorScheme(
             onErrorContainer = common.onErrorContainer,
             outline = common.outline,
             outlineVariant = common.outlineVariant,
-            scrim = Color.Black,
+            scrim = resolvedScrim,
             surfaceBright = liftedSurfaceBright,
             surfaceDim = liftedSurfaceDim,
             surfaceContainerLowest = liftedSurfaceContainerLowest,
@@ -317,10 +322,15 @@ private fun android.content.Context.resolveComposeColorScheme(
         val lightSurfaceContainerLowest = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerLowest.copy(alpha = 0.45f) else common.surfaceContainerLowest
         val lightSurfaceContainerLow = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerLow.copy(alpha = 0.50f) else common.surfaceContainerLow
         val lightSurfaceContainer = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainer.copy(alpha = 0.56f) else common.surfaceContainer
-        val lightSurfaceContainerHigh = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHigh.copy(alpha = 0.62f) else common.surfaceContainerHigh
-        val lightSurfaceContainerHighest = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHighest.copy(alpha = 0.68f) else common.surfaceContainerHighest
+        val lightSurfaceContainerHigh = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHigh.copy(alpha = 0.86f) else common.surfaceContainerHigh
+        val lightSurfaceContainerHighest = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHighest.copy(alpha = 0.90f) else common.surfaceContainerHighest
         val lightSurfaceVariant = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceVariant.copy(alpha = 0.55f) else common.surfaceVariant
         val lightSecondaryContainer = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.secondaryContainer.copy(alpha = 0.60f) else common.secondaryContainer
+        val resolvedScrim = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            Color(0xCC000000)
+        } else {
+            Color.Black
+        }
 
         lightColorScheme(
             primary = common.primary,
@@ -351,7 +361,7 @@ private fun android.content.Context.resolveComposeColorScheme(
             onErrorContainer = common.onErrorContainer,
             outline = common.outline,
             outlineVariant = common.outlineVariant,
-            scrim = Color.Black,
+            scrim = resolvedScrim,
             surfaceBright = common.surfaceBright,
             surfaceDim = common.surfaceDim,
             surfaceContainerLowest = lightSurfaceContainerLowest,

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt
@@ -214,38 +214,63 @@ private fun android.content.Context.resolveComposeColorScheme(
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(Color(0xFF0C0D0F), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color.Black
             BackgroundStyle.DEFAULT -> Color.Black
-            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color.Black
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color.Transparent
         }
         val baseSurface = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(Color(0xFF111316), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF141414)
             BackgroundStyle.DEFAULT -> Color.Black
-            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF0C0C0C)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF0A0A0E).copy(alpha = 0.45f)
         }
         val liftedSurfaceContainerLowest = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerLowest.liftForDarkContrast(0.10f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF121212)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF121216).copy(alpha = 0.40f)
             else -> common.surfaceContainerLowest.liftForDarkContrast(0.10f)
         }
         val liftedSurfaceContainerLow = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerLow.liftForDarkContrast(0.14f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF161616)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF16161A).copy(alpha = 0.46f)
             else -> common.surfaceContainerLow.liftForDarkContrast(0.14f)
         }
         val liftedSurfaceContainer = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainer.liftForDarkContrast(0.16f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF1E1E1E)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF1A1A20).copy(alpha = 0.52f)
             else -> common.surfaceContainer.liftForDarkContrast(0.16f)
         }
         val liftedSurfaceContainerHigh = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHigh.liftForDarkContrast(0.18f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF242424)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF202026).copy(alpha = 0.58f)
             else -> common.surfaceContainerHigh.liftForDarkContrast(0.18f)
         }
         val liftedSurfaceContainerHighest = when (backgroundStyle) {
             BackgroundStyle.SYSTEM_DYNAMIC_TINT -> lerp(common.surfaceContainerHighest.liftForDarkContrast(0.20f), common.primary, 0.08f)
             BackgroundStyle.ELEVATED_CONTAINERS -> Color(0xFF2C2C2C)
+            BackgroundStyle.DYNAMIC_ARTWORK_BLUR -> Color(0xFF26262E).copy(alpha = 0.64f)
             else -> common.surfaceContainerHighest.liftForDarkContrast(0.20f)
+        }
+        val liftedSurfaceVariant = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            common.surfaceVariant.copy(alpha = 0.52f)
+        } else {
+            common.surfaceVariant
+        }
+        val liftedSurfaceBright = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            common.surfaceBright.copy(alpha = 0.60f)
+        } else {
+            common.surfaceBright
+        }
+        val liftedSurfaceDim = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            common.surfaceDim.copy(alpha = 0.40f)
+        } else {
+            common.surfaceDim
+        }
+        val liftedSecondaryContainer = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+            common.secondaryContainer.copy(alpha = 0.55f)
+        } else {
+            common.secondaryContainer
         }
 
         darkColorScheme(
@@ -256,7 +281,7 @@ private fun android.content.Context.resolveComposeColorScheme(
             inversePrimary = common.inversePrimary,
             secondary = common.secondary,
             onSecondary = common.onSecondary,
-            secondaryContainer = common.secondaryContainer,
+            secondaryContainer = liftedSecondaryContainer,
             onSecondaryContainer = common.onSecondaryContainer,
             tertiary = common.tertiary,
             onTertiary = common.onTertiary,
@@ -266,7 +291,7 @@ private fun android.content.Context.resolveComposeColorScheme(
             onBackground = common.onBackground,
             surface = baseSurface,
             onSurface = common.onSurface,
-            surfaceVariant = common.surfaceVariant,
+            surfaceVariant = liftedSurfaceVariant,
             onSurfaceVariant = common.onSurfaceVariant,
             surfaceTint = common.primary,
             inverseSurface = common.inverseSurface,
@@ -278,8 +303,8 @@ private fun android.content.Context.resolveComposeColorScheme(
             outline = common.outline,
             outlineVariant = common.outlineVariant,
             scrim = Color.Black,
-            surfaceBright = common.surfaceBright,
-            surfaceDim = common.surfaceDim,
+            surfaceBright = liftedSurfaceBright,
+            surfaceDim = liftedSurfaceDim,
             surfaceContainerLowest = liftedSurfaceContainerLowest,
             surfaceContainerLow = liftedSurfaceContainerLow,
             surfaceContainer = liftedSurfaceContainer,
@@ -287,6 +312,16 @@ private fun android.content.Context.resolveComposeColorScheme(
             surfaceContainerHighest = liftedSurfaceContainerHighest,
         )
     } else {
+        val lightBg = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) Color.Transparent else common.background
+        val lightSurface = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surface.copy(alpha = 0.55f) else common.surface
+        val lightSurfaceContainerLowest = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerLowest.copy(alpha = 0.45f) else common.surfaceContainerLowest
+        val lightSurfaceContainerLow = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerLow.copy(alpha = 0.50f) else common.surfaceContainerLow
+        val lightSurfaceContainer = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainer.copy(alpha = 0.56f) else common.surfaceContainer
+        val lightSurfaceContainerHigh = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHigh.copy(alpha = 0.62f) else common.surfaceContainerHigh
+        val lightSurfaceContainerHighest = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceContainerHighest.copy(alpha = 0.68f) else common.surfaceContainerHighest
+        val lightSurfaceVariant = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.surfaceVariant.copy(alpha = 0.55f) else common.surfaceVariant
+        val lightSecondaryContainer = if (backgroundStyle == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) common.secondaryContainer.copy(alpha = 0.60f) else common.secondaryContainer
+
         lightColorScheme(
             primary = common.primary,
             onPrimary = common.onPrimary,
@@ -295,17 +330,17 @@ private fun android.content.Context.resolveComposeColorScheme(
             inversePrimary = common.inversePrimary,
             secondary = common.secondary,
             onSecondary = common.onSecondary,
-            secondaryContainer = common.secondaryContainer,
+            secondaryContainer = lightSecondaryContainer,
             onSecondaryContainer = common.onSecondaryContainer,
             tertiary = common.tertiary,
             onTertiary = common.onTertiary,
             tertiaryContainer = common.tertiaryContainer,
             onTertiaryContainer = common.onTertiaryContainer,
-            background = common.background,
+            background = lightBg,
             onBackground = common.onBackground,
-            surface = common.surface,
+            surface = lightSurface,
             onSurface = common.onSurface,
-            surfaceVariant = common.surfaceVariant,
+            surfaceVariant = lightSurfaceVariant,
             onSurfaceVariant = common.onSurfaceVariant,
             surfaceTint = common.primary,
             inverseSurface = common.inverseSurface,
@@ -319,11 +354,11 @@ private fun android.content.Context.resolveComposeColorScheme(
             scrim = Color.Black,
             surfaceBright = common.surfaceBright,
             surfaceDim = common.surfaceDim,
-            surfaceContainerLowest = common.surfaceContainerLowest,
-            surfaceContainerLow = common.surfaceContainerLow,
-            surfaceContainer = common.surfaceContainer,
-            surfaceContainerHigh = common.surfaceContainerHigh,
-            surfaceContainerHighest = common.surfaceContainerHighest,
+            surfaceContainerLowest = lightSurfaceContainerLowest,
+            surfaceContainerLow = lightSurfaceContainerLow,
+            surfaceContainer = lightSurfaceContainer,
+            surfaceContainerHigh = lightSurfaceContainerHigh,
+            surfaceContainerHighest = lightSurfaceContainerHighest,
         )
     }
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/MainActivity.kt
@@ -240,11 +240,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
             val appUpdate by viewModel.appUpdate.collectAsState(initial = null)
             val isIncognitoModeEnabled by viewModel.isIncognitoModeEnabled.collectAsState()
             val sourcePresets by sourcePresetsRepository.observeAll().collectAsState(initial = emptyList())
+            val lastReadContent by viewModel.lastReadContent.collectAsState()
 
             KototoroApp(
                 appSettings = settings,
                 navStateFlow = navStateFlow,
                 pageSaveHelper = pageSaveHelper,
+                lastReadContent = lastReadContent,
                 suggestions = suggestions,
                 onQueryChanged = ::updateSearchQuery,
                 onSearch = { query -> submitSearch(query) },

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/MainViewModel.kt
@@ -82,6 +82,14 @@ class MainViewModel @Inject constructor(
 			initialValue = false,
 		)
 
+	val lastReadContent = historyRepository.observeLast()
+		.withErrorHandling()
+		.stateIn(
+			scope = viewModelScope + Dispatchers.Default,
+			started = SharingStarted.WhileSubscribed(5000),
+			initialValue = null,
+		)
+
 	val appUpdate = appUpdateRepository.observeAvailableUpdate()
 
 	val feedCounter = trackingRepository.observeUnreadUpdatesCount()

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
@@ -997,7 +997,13 @@ fun KototoroApp(
             }
             Box(modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
+                .background(
+                    if (LocalBackgroundStyle.current == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+                        Color(0xFF08080C)
+                    } else {
+                        MaterialTheme.colorScheme.background
+                    }
+                )
                 .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
                 .nestedScroll(nestedScrollConnection)
                 .padding(start = displayCutoutStartDp, end = displayCutoutEndDp)) {
@@ -1031,7 +1037,7 @@ fun KototoroApp(
                             Box(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .background(Color.Black.copy(alpha = 0.80f))
+                                    .background(Color.Black.copy(alpha = 0.74f))
                             )
                         }
                     }

--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
@@ -113,6 +113,14 @@ import org.skepsun.kototoro.core.ui.compose.LocalRailAnimationFactor
 import org.skepsun.kototoro.core.ui.compose.LocalHeroTransitionPhase
 import org.skepsun.kototoro.core.ui.compose.HeroTransitionPhase
 import org.skepsun.kototoro.core.ui.compose.LocalHeroReturnTransitionInProgress
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
+import org.skepsun.kototoro.core.ui.theme.LocalBackgroundStyle
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import org.skepsun.kototoro.core.ui.compose.LocalHeroTransitionInProgress
 import org.skepsun.kototoro.core.ui.compose.LocalSharedTransitionScope
 import org.skepsun.kototoro.core.ui.compose.heroTransitionTimestampMs
@@ -273,6 +281,7 @@ fun KototoroApp(
     appSettings: AppSettings,
     navStateFlow: StateFlow<BottomNavState>,
     pageSaveHelper: org.skepsun.kototoro.reader.ui.PageSaveHelper,
+    lastReadContent: Content? = null,
     query: String = "",
     suggestions: List<SearchSuggestionItem> = emptyList(),
     onQueryChanged: (String) -> Unit = {},
@@ -992,6 +1001,41 @@ fun KototoroApp(
                 .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
                 .nestedScroll(nestedScrollConnection)
                 .padding(start = displayCutoutStartDp, end = displayCutoutEndDp)) {
+                if (LocalBackgroundStyle.current == BackgroundStyle.DYNAMIC_ARTWORK_BLUR) {
+                    val cover = lastReadContent?.coverUrl ?: lastReadContent?.publicUrl
+                    if (!cover.isNullOrEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .drawWithCache {
+                                    onDrawWithContent {
+                                        drawContent()
+                                    }
+                                }
+                        ) {
+                            androidx.compose.foundation.Image(
+                                painter = rememberAsyncImagePainter(
+                                    model = ImageRequest.Builder(LocalContext.current)
+                                        .data(cover)
+                                        .crossfade(true)
+                                        .build()
+                                ),
+                                contentDescription = null,
+                                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer {
+                                        renderEffect = androidx.compose.ui.graphics.BlurEffect(35f, 35f)
+                                    }
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(Color.Black.copy(alpha = 0.80f))
+                            )
+                        }
+                    }
+                }
                 SharedTransitionLayout {
                     SideEffect {
                         chromeSharedTransitionScope = if (effectiveSharedElementTransitionsEnabled) {
@@ -1278,57 +1322,73 @@ private fun BoxScope.MainTopChrome(
             modifier = topChromeModifier,
         )
     } else {
-        KototoroTopBar(
-            query = query,
-            titleRes = titleRes,
-            onSearchClick = onSearchClick,
-            onOpenListOptions = onOpenListOptions,
-            onSettingsClick = onSettingsClick,
-            onSourceSettingsClick = onSourceSettingsClick,
-            onManageSourcesClick = onManageSourcesClick,
-            onTrackingAccountsClick = onTrackingAccountsClick,
-            isAppUpdateAvailable = isAppUpdateAvailable,
-            onAppUpdateClick = onAppUpdateClick,
-            isIncognitoModeEnabled = isIncognitoModeEnabled,
-            onIncognitoToggle = onIncognitoToggle,
-            isLanguagePresetFilterVisible = isLanguagePresetFilterVisible,
-            languagePresetEntries = languagePresetEntries,
-            activeLanguagePresetId = activeLanguagePresetId,
-            onLanguagePresetSelected = onLanguagePresetSelected,
-            onManageLanguagePresets = onManageLanguagePresets,
-            compactTabsState = topTabsOverrideState,
-            filterRailState = topFilterRailOverrideState,
-            selectedContentType = selectedContentType,
-            enabledContentTypes = enabledContentTypes,
-            isContentTypeFilterVisible = isContentTypeFilterVisible,
-            onContentTypeSelected = onContentTypeSelected,
-            selectedSourceTags = selectedSourceTags,
-            sourceTagEntries = sourceTagEntries,
-            enabledSourceTags = enabledSourceTags,
-            isSourceTagFilterVisible = isSourceTagFilterVisible,
-            onSourceTagFilterClick = onSourceTagFilterClick,
-            onSourceTagSelected = onSourceTagSelected,
-            supportsDisplayModeMenu = supportsDisplayModeMenu,
-            currentListMode = currentListMode,
-            onListModeSelected = onListModeSelected,
-            supportsGridSizeSlider = supportsGridSizeSlider,
-            gridSize = gridSize,
-            onGridSizeChange = onGridSizeChange,
-            isBrowseTrackingRecommendationsEnabled = isBrowseTrackingRecommendationsEnabled,
-            onBrowseTrackingRecommendationsChange = onBrowseTrackingRecommendationsChange,
-            isBrowseMoreTrackingRecommendationsEnabled = isBrowseMoreTrackingRecommendationsEnabled,
-            onBrowseMoreTrackingRecommendationsChange = onBrowseMoreTrackingRecommendationsChange,
-            showSourceSettingsEntry = showSourceSettingsEntry,
-            contextualMenuActions = contextualMenuActions,
-            forceCompactTabsExpanded = forceCompactTabsExpanded,
-            sortOrders = sortOrders,
-            selectedSortOrder = selectedSortOrder,
-            onSortOrderSelected = onSortOrderSelected,
-            displayOptionsExtraContent = displayOptionsExtraContent,
-            modifier = topChromeModifier.offset {
-                androidx.compose.ui.unit.IntOffset(0, (effectiveCompactTabsTopBarOffset - effectiveTopBarOffset).toInt())
-            },
-        )
+        val topContent: @Composable () -> Unit = {
+            KototoroTopBar(
+                query = query,
+                titleRes = titleRes,
+                onSearchClick = onSearchClick,
+                onOpenListOptions = onOpenListOptions,
+                onSettingsClick = onSettingsClick,
+                onSourceSettingsClick = onSourceSettingsClick,
+                onManageSourcesClick = onManageSourcesClick,
+                onTrackingAccountsClick = onTrackingAccountsClick,
+                isAppUpdateAvailable = isAppUpdateAvailable,
+                onAppUpdateClick = onAppUpdateClick,
+                isIncognitoModeEnabled = isIncognitoModeEnabled,
+                onIncognitoToggle = onIncognitoToggle,
+                isLanguagePresetFilterVisible = isLanguagePresetFilterVisible,
+                languagePresetEntries = languagePresetEntries,
+                activeLanguagePresetId = activeLanguagePresetId,
+                onLanguagePresetSelected = onLanguagePresetSelected,
+                onManageLanguagePresets = onManageLanguagePresets,
+                compactTabsState = topTabsOverrideState,
+                filterRailState = topFilterRailOverrideState,
+                selectedContentType = selectedContentType,
+                enabledContentTypes = enabledContentTypes,
+                isContentTypeFilterVisible = isContentTypeFilterVisible,
+                onContentTypeSelected = onContentTypeSelected,
+                selectedSourceTags = selectedSourceTags,
+                sourceTagEntries = sourceTagEntries,
+                enabledSourceTags = enabledSourceTags,
+                isSourceTagFilterVisible = isSourceTagFilterVisible,
+                onSourceTagFilterClick = onSourceTagFilterClick,
+                onSourceTagSelected = onSourceTagSelected,
+                supportsDisplayModeMenu = supportsDisplayModeMenu,
+                currentListMode = currentListMode,
+                onListModeSelected = onListModeSelected,
+                supportsGridSizeSlider = supportsGridSizeSlider,
+                gridSize = gridSize,
+                onGridSizeChange = onGridSizeChange,
+                isBrowseTrackingRecommendationsEnabled = isBrowseTrackingRecommendationsEnabled,
+                onBrowseTrackingRecommendationsChange = onBrowseTrackingRecommendationsChange,
+                isBrowseMoreTrackingRecommendationsEnabled = isBrowseMoreTrackingRecommendationsEnabled,
+                onBrowseMoreTrackingRecommendationsChange = onBrowseMoreTrackingRecommendationsChange,
+                showSourceSettingsEntry = showSourceSettingsEntry,
+                contextualMenuActions = contextualMenuActions,
+                forceCompactTabsExpanded = forceCompactTabsExpanded,
+                sortOrders = sortOrders,
+                selectedSortOrder = selectedSortOrder,
+                onSortOrderSelected = onSortOrderSelected,
+                displayOptionsExtraContent = displayOptionsExtraContent,
+                modifier = topChromeModifier.offset {
+                    androidx.compose.ui.unit.IntOffset(0, (effectiveCompactTabsTopBarOffset - effectiveTopBarOffset).toInt())
+                },
+            )
+        }
+        if (LocalBackgroundStyle.current == BackgroundStyle.ELEVATED_CONTAINERS) {
+            Surface(
+                shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shadowElevation = 4.dp,
+                modifier = topChromeModifier.offset {
+                    androidx.compose.ui.unit.IntOffset(0, (effectiveCompactTabsTopBarOffset - effectiveTopBarOffset).toInt())
+                }
+            ) {
+                topContent()
+            }
+        } else {
+            topContent()
+        }
     }
 }
 
@@ -1516,12 +1576,26 @@ private fun BoxScope.MainBottomChrome(
                 onBottomNavHeightMeasured(newHeight)
             },
     ) {
-        KototoroBottomNav(
-            state = navStateFlow,
-            onItemSelected = onItemSelected,
-            onItemReselected = onItemReselected,
-            showContinueReadingButton = isLandscapeNavigation && isResumeEnabled,
-            onContinueReadingClick = onResumeClick,
-        )
+        val bottomNavContent: @Composable () -> Unit = {
+            KototoroBottomNav(
+                state = navStateFlow,
+                onItemSelected = onItemSelected,
+                onItemReselected = onItemReselected,
+                showContinueReadingButton = isLandscapeNavigation && isResumeEnabled,
+                onContinueReadingClick = onResumeClick,
+            )
+        }
+        if (LocalBackgroundStyle.current == BackgroundStyle.ELEVATED_CONTAINERS) {
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shadowElevation = 6.dp,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+            ) {
+                bottomNavContent()
+            }
+        } else {
+            bottomNavContent()
+        }
     }
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/AppearanceSettingsFragment.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/AppearanceSettingsFragment.kt
@@ -26,6 +26,7 @@ import org.skepsun.kototoro.R
 import org.skepsun.kototoro.core.os.AppShortcutManager
 import org.skepsun.kototoro.core.prefs.AppSettings
 import org.skepsun.kototoro.core.prefs.AppFontPreset
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
 import org.skepsun.kototoro.core.prefs.ColorScheme
 import org.skepsun.kototoro.core.prefs.ListMode
 import org.skepsun.kototoro.core.prefs.NavItem
@@ -153,6 +154,7 @@ private class AppearanceSettingsCoordinator(
         val coroutineScope = rememberCoroutineScope()
         val colorScheme = settings.observeAsState(AppSettings.KEY_COLOR_THEME) { colorScheme }.value
         val theme = settings.observeAsState(AppSettings.KEY_THEME) { theme }.value
+        val backgroundStyle = settings.observeAsState(AppSettings.KEY_BACKGROUND_STYLE) { backgroundStyle }.value
         val isAmoledTheme = settings.observeAsState(AppSettings.KEY_THEME_AMOLED) { isAmoledTheme }.value
         val isMaterialExpressiveComponentsEnabled =
             settings.observeAsState(AppSettings.KEY_MATERIAL_EXPRESSIVE_COMPONENTS) {
@@ -283,6 +285,7 @@ private class AppearanceSettingsCoordinator(
         val options = AppearanceSettingsOptions(
             colorSchemes = buildColorSchemeOptions(),
             themes = buildThemeOptions(),
+            backgroundStyles = buildBackgroundStyleOptions(),
             fontPresets = buildFontPresetOptions(),
             glassMaterialFamilies = buildGlassMaterialFamilyOptions(),
             tabletUiModes = buildTabletUiModeOptions(),
@@ -306,6 +309,7 @@ private class AppearanceSettingsCoordinator(
             navSummary = buildNavSummary(mainNavItems),
             colorScheme = colorScheme,
             theme = theme,
+            backgroundStyle = backgroundStyle,
             isAmoledTheme = isAmoledTheme,
             isMaterialExpressiveComponentsEnabled = isMaterialExpressiveComponentsEnabled,
             appFontPreset = appFontPreset,
@@ -381,6 +385,7 @@ private class AppearanceSettingsCoordinator(
             emptySelectionText = context.getString(R.string.none),
             onColorSchemeChange = { updateAndRestart(coroutineScope) { settings.colorScheme = it } },
             onThemeChange = ::updateTheme,
+            onBackgroundStyleChange = { updateAndRestart(coroutineScope) { settings.backgroundStyle = it } },
             onAmoledThemeChange = { updateAndRestart(coroutineScope) { settings.isAmoledTheme = it } },
             onMaterialExpressiveComponentsChange = {
                 updateAndRestart(coroutineScope) { settings.isMaterialExpressiveComponentsEnabled = it }
@@ -523,6 +528,15 @@ private class AppearanceSettingsCoordinator(
         val labels = context.resources.getStringArray(R.array.themes)
         val values = context.resources.getStringArray(R.array.values_theme).map { it.toInt() }
         return labels.zip(values).map { (label, value) -> SettingsChoiceOption(value, label) }
+    }
+
+    private fun buildBackgroundStyleOptions(): List<SettingsChoiceOption<BackgroundStyle>> {
+        return listOf(
+            SettingsChoiceOption(BackgroundStyle.DEFAULT, context.getString(R.string.bg_style_default)),
+            SettingsChoiceOption(BackgroundStyle.DYNAMIC_ARTWORK_BLUR, context.getString(R.string.bg_style_artwork_blur)),
+            SettingsChoiceOption(BackgroundStyle.SYSTEM_DYNAMIC_TINT, context.getString(R.string.bg_style_system_tint)),
+            SettingsChoiceOption(BackgroundStyle.ELEVATED_CONTAINERS, context.getString(R.string.bg_style_elevated_containers)),
+        )
     }
 
     private fun buildGlassMaterialFamilyOptions(): List<SettingsChoiceOption<GlassMaterialFamily>> {

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/AppearanceSettingsScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/AppearanceSettingsScreen.kt
@@ -22,6 +22,7 @@ import org.skepsun.kototoro.core.ui.compose.PanoramaAnimationSpeedMinPercent
 import org.skepsun.kototoro.core.prefs.AppSettings
 import org.skepsun.kototoro.core.prefs.AppSettings.GlassMaterialFamily
 import org.skepsun.kototoro.core.prefs.AppFontPreset
+import org.skepsun.kototoro.core.prefs.BackgroundStyle
 import org.skepsun.kototoro.core.prefs.ColorScheme
 import org.skepsun.kototoro.core.prefs.AppSettings.GlassMaterialPreset
 import org.skepsun.kototoro.core.prefs.ListMode
@@ -34,6 +35,7 @@ data class AppearanceSettingsUiState(
     val navSummary: String,
     val colorScheme: ColorScheme,
     val theme: Int,
+    val backgroundStyle: BackgroundStyle,
     val isAmoledTheme: Boolean,
     val isMaterialExpressiveComponentsEnabled: Boolean,
     val appFontPreset: AppFontPreset,
@@ -106,6 +108,7 @@ data class AppearanceSettingsUiState(
 data class AppearanceSettingsOptions(
     val colorSchemes: List<SettingsChoiceOption<ColorScheme>>,
     val themes: List<SettingsChoiceOption<Int>>,
+    val backgroundStyles: List<SettingsChoiceOption<BackgroundStyle>>,
     val fontPresets: List<SettingsChoiceOption<AppFontPreset>>,
     val glassMaterialFamilies: List<SettingsChoiceOption<GlassMaterialFamily>>,
     val tabletUiModes: List<SettingsChoiceOption<TabletUiMode>>,
@@ -132,6 +135,7 @@ fun AppearanceSettingsScreen(
     emptySelectionText: String,
     onColorSchemeChange: (ColorScheme) -> Unit,
     onThemeChange: (Int) -> Unit,
+    onBackgroundStyleChange: (BackgroundStyle) -> Unit,
     onAmoledThemeChange: (Boolean) -> Unit,
     onMaterialExpressiveComponentsChange: (Boolean) -> Unit,
     onAppFontPresetChange: (AppFontPreset) -> Unit,
@@ -224,6 +228,14 @@ fun AppearanceSettingsScreen(
                     value = state.theme,
                     options = options.themes,
                     onValueChange = onThemeChange,
+                )
+                SettingsSectionDivider()
+                SettingsChoicePreference(
+                    title = stringResource(R.string.background_style),
+                    value = state.backgroundStyle,
+                    options = options.backgroundStyles,
+                    summary = stringResource(R.string.background_style_summary),
+                    onValueChange = onBackgroundStyleChange,
                 )
                 SettingsSectionDivider()
                 SettingsSwitchPreference(

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/SettingsPreferenceComponents.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/SettingsPreferenceComponents.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.skepsun.kototoro.core.ui.glass.ApplyDynamicArtworkBlurDialogStyle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -379,6 +380,7 @@ fun <T> SettingsChoicePreference(
     }
 
     if (isDialogVisible) {
+        ApplyDynamicArtworkBlurDialogStyle()
         AlertDialog(
             onDismissRequest = { isDialogVisible = false },
             title = { Text(text = title) },
@@ -482,6 +484,7 @@ fun <T> SettingsMultiChoicePreference(
     }
 
     if (isDialogVisible) {
+        ApplyDynamicArtworkBlurDialogStyle()
         AlertDialog(
             onDismissRequest = { isDialogVisible = false },
             title = { Text(text = title) },
@@ -711,6 +714,7 @@ fun SettingsDialogTextPreference(
     }
 
     if (isDialogVisible) {
+        ApplyDynamicArtworkBlurDialogStyle()
         AlertDialog(
             onDismissRequest = {
                 isSuggestionsExpanded = false
@@ -847,6 +851,7 @@ fun SettingsReorderPreference(
     }
 
     if (isDialogVisible) {
+        ApplyDynamicArtworkBlurDialogStyle()
         AlertDialog(
             onDismissRequest = { isDialogVisible = false },
             title = { Text(text = title) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,16 @@
     <string name="zoom_mode_keep_start">Keep at start</string>
     <string name="black_dark_theme">Black</string>
     <string name="black_dark_theme_summary">Uses less power on AMOLED screens</string>
+    <string name="background_style">Background style</string>
+    <string name="background_style_summary">Choose how the app background and container depth are styled</string>
+    <string name="bg_style_default">Default (Pure Black)</string>
+    <string name="bg_style_default_summary">True #000000 pitch-black background optimized for OLED displays</string>
+    <string name="bg_style_artwork_blur">Dynamic Artwork Blur (Immersive)</string>
+    <string name="bg_style_artwork_blur_summary">Cover artwork with heavy Gaussian blur and 80% dark dimming overlay</string>
+    <string name="bg_style_system_tint">System Dynamic Tint (Material You)</string>
+    <string name="bg_style_system_tint_summary">Extract wallpaper colors for a premium, low-chroma custom-tinted dark background</string>
+    <string name="bg_style_elevated_containers">Elevated Containers (Depth Mode)</string>
+    <string name="bg_style_elevated_containers_summary">Pure black background with lighter dark gray surfaces and rounded corners for depth</string>
     <string name="backup_restore">Backup and restore</string>
     <string name="create_backup">Backup</string>
     <string name="restore_backup">Restore from backup</string>


### PR DESCRIPTION
This pull request introduces a new customizable background style system to the app, allowing users to select between several visual background modes, including a dynamic artwork blur effect. The changes add the `BackgroundStyle` enum, persist the selected style in settings, and propagate it throughout the UI via a new composition local. The theme and dialog appearance logic have been updated to respect the selected background style, with special handling for the dynamic artwork blur mode, including real-time window blurring and color adjustments.

**Background Style System Implementation:**

* Added the `BackgroundStyle` enum to represent different background modes, such as default, dynamic artwork blur, system dynamic tint, and elevated containers. (`app/src/main/kotlin/org/skepsun/kototoro/core/prefs/BackgroundStyle.kt`)
* Persisted the selected background style in `AppSettings` and exposed it as a property, including the new preference key. (`app/src/main/kotlin/org/skepsun/kototoro/core/prefs/AppSettings.kt`) [[1]](diffhunk://#diff-251b1b693f6b74338a48bbf52ebd6b1a13b7f1af03c955f965aa2f1262d662feR145-R148) [[2]](diffhunk://#diff-251b1b693f6b74338a48bbf52ebd6b1a13b7f1af03c955f965aa2f1262d662feR2113)

**Theme and UI Integration:**

* Introduced `LocalBackgroundStyle` as a composition local and provided it in the `KototoroTheme`, allowing the background style to be accessed throughout the UI. (`app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt`) [[1]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911R34-R37) [[2]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L89-R98)
* Updated the color scheme logic in `KototoroTheme` to use the selected background style, including special color and alpha handling for the dynamic artwork blur mode in both dark and light themes. (`app/src/main/kotlin/org/skepsun/kototoro/core/ui/theme/KototoroTheme.kt`) [[1]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L55-R62) [[2]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911R166) [[3]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L203-R279) [[4]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L217-R299) [[5]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L238-R334) [[6]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L256-R353) [[7]](diffhunk://#diff-85f01a9bfd61dcc4934f6154920c9c6466ad28ba375f20c6b87c5d39b031e911L277-R371)

**Dialog and Surface Visuals:**

* Added `ApplyDynamicArtworkBlurDialogStyle`, a composable that applies real-time native window blurring and dimming to dialogs when the dynamic artwork blur style is active. (`app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/KototoroDialogHelper.kt`)
* Updated `GlassSurface` to use the selected background style when rendering dialog surfaces, adjusting alpha and color accordingly. (`app/src/main/kotlin/org/skepsun/kototoro/core/ui/glass/GlassSurface.kt`)

These changes collectively enable a richer and more customizable visual experience, with robust support for dynamic and blurred backgrounds across the app UI.