### PR TITLE
Merge repeated chapters in reader

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/model/ContentChapterExt.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/model/ContentChapterExt.kt
@@ -1,0 +1,43 @@
+package org.skepsun.kototoro.core.model
+
+import org.skepsun.kototoro.parsers.model.ContentChapter
+import org.skepsun.kototoro.parsers.model.ContentType
+
+fun ContentChapter.getMergeKey(): String {
+	return if (number > 0f) {
+		val volKey = if (volume > 0) volume else null
+		"num_${volKey}_${number}"
+	} else {
+		val titleKey = title?.lowercase()?.trim()
+		if (!titleKey.isNullOrBlank()) {
+			"title_$titleKey"
+		} else {
+			"unique_${id}_${url}"
+		}
+	}
+}
+
+fun List<ContentChapter>.mergeRepeated(): List<ContentChapter> {
+	if (this.isEmpty()) return this
+	val groups = this.groupBy { it.getMergeKey() }
+	return groups.map { (_, groupList) ->
+		if (groupList.size == 1) {
+			groupList.first()
+		} else {
+			groupList.maxWithOrNull(
+				compareBy<ContentChapter> { it.uploadDate }
+					.thenBy { it.url.startsWith("file:") || it.url.startsWith("zip:") || it.url.startsWith("file+zip:") || it.url.startsWith("content:") || it.url.startsWith("epub:") || it.url.startsWith("localepub:") }
+					.thenBy { it.scanlator?.isNotBlank() == true }
+					.thenBy { it.title?.length ?: 0 }
+			) ?: groupList.first()
+		}
+	}
+}
+
+fun ContentType?.isManga(): Boolean {
+	this ?: return true
+	return this != ContentType.VIDEO &&
+		this != ContentType.HENTAI_VIDEO &&
+		this != ContentType.NOVEL &&
+		this != ContentType.HENTAI_NOVEL
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt
@@ -3056,9 +3056,10 @@ class DetailsViewModel @Inject constructor(
 		selectedBranch,
 		history,
 		interactor.observeIncognitoMode(manga),
-	) { m, b, h, im ->
+		isMergeRepeatedChapters,
+	) { m, b, h, im, mergeRepeated ->
 		val estimatedTime = readingTimeUseCase.invoke(m, b, h)
-		HistoryInfo(m, b, h, im == TriStateOption.ENABLED, estimatedTime)
+		HistoryInfo(m, b, h, im == TriStateOption.ENABLED, estimatedTime, mergeRepeated)
 	}.withErrorHandling()
 		.stateIn(
 			scope = viewModelScope + Dispatchers.Default,

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt
@@ -32,6 +32,10 @@ import org.skepsun.kototoro.parsers.model.ContentType
 
 import org.skepsun.kototoro.core.model.unwrap
 import org.skepsun.kototoro.core.model.getContentType
+import org.skepsun.kototoro.parsers.model.ContentChapter
+import org.skepsun.kototoro.core.model.getMergeKey
+import org.skepsun.kototoro.core.model.mergeRepeated
+import org.skepsun.kototoro.core.model.isManga
 
 internal fun openDetailsReader(
 	context: Context,
@@ -71,8 +75,24 @@ internal fun openDetailsReader(
 			intentBuilder.state(state)
 		} else if (history != null && !manga.chapters.isNullOrEmpty()) {
 			val preferredBranch = viewModel.selectedBranchValue
-			val chapters = manga.chapters?.filter { it.branch == preferredBranch } ?: manga.chapters
+			val useMerge = viewModel.isMergeRepeatedChapters.value && contentType.isManga()
+			val details = viewModel.mangaDetails.value
+			val chapters = if (useMerge && details != null) {
+				val allBranches = details.chapters.keys.toList()
+				val rawChapters = allBranches.flatMap { details.chapters[it].orEmpty() }
+				rawChapters.mergeRepeated()
+			} else {
+				manga.chapters?.filter { it.branch == preferredBranch } ?: manga.chapters
+			}
 			var matchedChapter = chapters?.find { it.id == history.chapterId }
+
+			if (matchedChapter == null && useMerge && details != null) {
+				val historyChapter = details.allChapters.find { it.id == history.chapterId }
+				if (historyChapter != null) {
+					val historyKey = historyChapter.getMergeKey()
+					matchedChapter = chapters?.find { it.getMergeKey() == historyKey }
+				}
+			}
 
 			if (matchedChapter == null) {
 				val potentialParentChapter = chapters?.find { it.id == history.chapterId }

--- a/app/src/main/kotlin/org/skepsun/kototoro/details/ui/model/HistoryInfo.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/details/ui/model/HistoryInfo.kt
@@ -4,6 +4,10 @@ import org.skepsun.kototoro.core.model.ContentHistory
 import org.skepsun.kototoro.details.data.ContentDetails
 import org.skepsun.kototoro.details.data.ReadingTime
 import org.skepsun.kototoro.parsers.model.ContentChapter
+import org.skepsun.kototoro.core.model.getMergeKey
+import org.skepsun.kototoro.core.model.mergeRepeated
+import org.skepsun.kototoro.core.model.isManga
+import org.skepsun.kototoro.core.model.getContentType
 
 private const val EPUB_HISTORY_MATCH_WINDOW = 1_000_000L
 
@@ -36,14 +40,29 @@ fun HistoryInfo(
 	history: ContentHistory?,
 	isIncognitoMode: Boolean,
 	estimatedTime: ReadingTime?,
+	isMergeRepeatedChapters: Boolean = false,
 ): HistoryInfo {
+	val contentType = manga?.toContent()?.source?.getContentType()
+	val useMerge = isMergeRepeatedChapters && contentType.isManga()
 	val chapters = if (manga?.chapters?.isEmpty() == true) {
 		emptyList()
+	} else if (useMerge && manga != null) {
+		val allBranches = manga.chapters.keys.toList()
+		val rawChapters = allBranches.flatMap { manga.chapters[it].orEmpty() }
+		rawChapters.mergeRepeated()
 	} else {
 		manga?.chapters?.get(branch)
 	}
 	var currentChapter = if (history != null && !chapters.isNullOrEmpty()) {
-		chapters.findChapterByHistory(history)?.let(chapters::indexOf) ?: -1
+		var index = chapters.findChapterByHistory(history)?.let(chapters::indexOf) ?: -1
+		if (index == -1 && useMerge && manga != null) {
+			val historyChapter = manga.allChapters.find { it.id == history.chapterId }
+			if (historyChapter != null) {
+				val historyKey = historyChapter.getMergeKey()
+				index = chapters.indexOfFirst { it.getMergeKey() == historyKey }
+			}
+		}
+		index
 	} else {
 		-2
 	}

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/ChaptersLoader.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/domain/ChaptersLoader.kt
@@ -14,6 +14,11 @@ import org.skepsun.kototoro.details.data.ContentDetails
 import org.skepsun.kototoro.parsers.model.ContentChapter
 import org.skepsun.kototoro.parsers.model.ContentPage
 import org.skepsun.kototoro.reader.ui.pager.ReaderPage
+import org.skepsun.kototoro.core.prefs.AppSettings
+import org.skepsun.kototoro.core.model.getMergeKey
+import org.skepsun.kototoro.core.model.mergeRepeated
+import org.skepsun.kototoro.core.model.isManga
+import org.skepsun.kototoro.core.model.getContentType
 import javax.inject.Inject
 
 private const val PAGES_TRIM_THRESHOLD = 120
@@ -21,6 +26,7 @@ private const val PAGES_TRIM_THRESHOLD = 120
 @ViewModelScoped
 class ChaptersLoader @Inject constructor(
 	private val mangaRepositoryFactory: ContentRepository.Factory,
+	private val settings: AppSettings,
 ) {
 
 	private val chapters = LongSparseArray<ContentChapter>()
@@ -38,11 +44,32 @@ class ChaptersLoader @Inject constructor(
 	}
 
 	suspend fun loadPrevNextChapter(manga: ContentDetails, currentId: Long, isNext: Boolean): Boolean {
-		val chapters = manga.allChapters
-		val predicate: (ContentChapter) -> Boolean = { it.id == currentId }
-		val index = if (isNext) chapters.indexOfFirst(predicate) else chapters.indexOfLast(predicate)
+		val contentType = manga.toContent().source.getContentType()
+		val useMerge = settings.isMergeRepeatedChapters && contentType.isManga()
+		val chaptersList = if (useMerge) {
+			val allBranches = manga.chapters.keys.toList()
+			val rawChapters = allBranches.flatMap { manga.chapters[it].orEmpty() }
+			rawChapters.mergeRepeated()
+		} else {
+			manga.allChapters
+		}
+
+		val currentChapter = peekChapter(currentId) ?: manga.allChapters.find { it.id == currentId }
+		val index = if (currentChapter != null) {
+			val currentKey = if (useMerge) currentChapter.getMergeKey() else null
+			if (useMerge) {
+				chaptersList.indexOfFirst { it.getMergeKey() == currentKey }
+			} else {
+				val predicate: (ContentChapter) -> Boolean = { it.id == currentId }
+				if (isNext) chaptersList.indexOfFirst(predicate) else chaptersList.indexOfLast(predicate)
+			}
+		} else {
+			val predicate: (ContentChapter) -> Boolean = { it.id == currentId }
+			if (isNext) chaptersList.indexOfFirst(predicate) else chaptersList.indexOfLast(predicate)
+		}
+
 		if (index == -1) return false
-		val newChapter = chapters.getOrNull(if (isNext) index + 1 else index - 1) ?: return false
+		val newChapter = chaptersList.getOrNull(if (isNext) index + 1 else index - 1) ?: return false
 		val newPages = loadChapter(newChapter.id)
 		mutex.withLock {
 			if (chapterPages.chaptersSize > 1) {
@@ -62,6 +89,22 @@ class ChaptersLoader @Inject constructor(
 			}
 		}
 		return true
+	}
+
+	suspend fun keepOnlyChapter(chapterId: Long) = mutex.withLock {
+		if (chapterId !in chapterPages) {
+			chapterPages.clear()
+			return@withLock
+		}
+		while (chapterPages.chaptersSize > 1) {
+			if (chapterPages.first().chapterId != chapterId) {
+				chapterPages.removeFirst()
+			} else if (chapterPages.last().chapterId != chapterId) {
+				chapterPages.removeLast()
+			} else {
+				break
+			}
+		}
 	}
 
 	@CheckResult

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -70,6 +71,11 @@ import org.skepsun.kototoro.parsers.util.sizeOrZero
 import org.skepsun.kototoro.readingrecord.data.ReadingRecordRepository
 import org.skepsun.kototoro.reader.domain.ChaptersLoader
 import org.skepsun.kototoro.reader.domain.DetectReaderModeUseCase
+import org.skepsun.kototoro.parsers.model.ContentChapter
+import org.skepsun.kototoro.core.model.getMergeKey
+import org.skepsun.kototoro.core.model.mergeRepeated
+import org.skepsun.kototoro.core.model.isManga
+import org.skepsun.kototoro.core.model.getContentType
 import org.skepsun.kototoro.reader.domain.PageLoader
 import org.skepsun.kototoro.reader.domain.ReaderPageEnhancementController
 import org.skepsun.kototoro.reader.domain.TranslationLayerState
@@ -261,6 +267,7 @@ class ReaderViewModel @Inject constructor(
         observeTranslationLayerState()
         observeTranslationDebugLogs()
         listenToDoublePageEvents()
+        observeMergeRepeatedChapters()
         loadImpl()
 		launchJob(Dispatchers.Default) {
 			val mangaId = manga.filterNotNull().first().id
@@ -587,13 +594,20 @@ class ReaderViewModel @Inject constructor(
             prevJob?.cancelAndJoin()
             val prevState = readingState.requireValue()
             val newChapterId = if (delta != 0) {
-                val allChapters = mangaDetails.requireValue().allChapters
-                var index = allChapters.indexOfFirst { x -> x.id == prevState.chapterId }
+                val readingChapters = getReadingChapters()
+                var index = readingChapters.indexOfFirst { x -> x.id == prevState.chapterId }
+                if (index < 0 && isMergeRepeatedChapters.value) {
+                    val currentChapter = chaptersLoader.peekChapter(prevState.chapterId)
+                    if (currentChapter != null) {
+                        val currentKey = currentChapter.getMergeKey()
+                        index = readingChapters.indexOfFirst { it.getMergeKey() == currentKey }
+                    }
+                }
                 if (index < 0) {
                     return@launchLoadingJob
                 }
                 index += delta
-                (allChapters.getOrNull(index) ?: return@launchLoadingJob).id
+                (readingChapters.getOrNull(index) ?: return@launchLoadingJob).id
             } else {
                 prevState.chapterId
             }
@@ -840,7 +854,7 @@ class ReaderViewModel @Inject constructor(
                                 }
                             }
                         }
-                        mangaDetails.value = details.filterChapters(selectedBranch.value)
+                        mangaDetails.value = details
 
                         // save state
                         if (isIncognitoMode.value == false) {
@@ -861,7 +875,7 @@ class ReaderViewModel @Inject constructor(
             if (readingState.value == null) {
                 val loadedContent = loadedDetails // for smart cast
                 if (loadedContent != null) {
-                    mangaDetails.value = loadedContent.filterChapters(selectedBranch.value)
+                    mangaDetails.value = loadedContent
                 }
                 val loadingError = when {
                     exception != null -> exception
@@ -977,12 +991,17 @@ class ReaderViewModel @Inject constructor(
         val state = getCurrentState() ?: return
         val chapter = chaptersLoader.peekChapter(state.chapterId) ?: return
         val m = mangaDetails.value ?: return
-        val chapterIndex = m.chapters[chapter.branch]?.indexOfFirst { it.id == chapter.id } ?: -1
+        val readingChapters = getReadingChapters()
+        var chapterIndex = readingChapters.indexOfFirst { it.id == chapter.id }
+        if (chapterIndex < 0 && isMergeRepeatedChapters.value) {
+            val currentKey = chapter.getMergeKey()
+            chapterIndex = readingChapters.indexOfFirst { it.getMergeKey() == currentKey }
+        }
         val newState = ReaderUiState(
             mangaName = m.toContent().title,
             chapter = chapter,
             chapterIndex = chapterIndex,
-            chaptersTotal = m.chapters[chapter.branch].sizeOrZero(),
+            chaptersTotal = readingChapters.size,
             totalPages = chaptersLoader.getPagesCount(chapter.id),
             currentPage = state.page,
             percent = computePercent(state.chapterId, state.page),
@@ -997,12 +1016,18 @@ class ReaderViewModel @Inject constructor(
     }
 
     private fun computePercent(chapterId: Long, pageIndex: Int): Float {
-        val branch = chaptersLoader.peekChapter(chapterId)?.branch
-        val chapters = mangaDetails.value?.chapters?.get(branch) ?: return PROGRESS_NONE
-        val chaptersCount = chapters.size
-        val chapterIndex = chapters.indexOfFirst { x -> x.id == chapterId }
+        val readingChapters = getReadingChapters()
+        val chaptersCount = readingChapters.size
+        var chapterIndex = readingChapters.indexOfFirst { x -> x.id == chapterId }
+        if (chapterIndex < 0 && isMergeRepeatedChapters.value) {
+            val currentChapter = chaptersLoader.peekChapter(chapterId)
+            if (currentChapter != null) {
+                val currentKey = currentChapter.getMergeKey()
+                chapterIndex = readingChapters.indexOfFirst { it.getMergeKey() == currentKey }
+            }
+        }
         val pagesCount = chaptersLoader.getPagesCount(chapterId)
-        if (chaptersCount == 0 || pagesCount == 0) {
+        if (chaptersCount == 0 || pagesCount == 0 || chapterIndex == -1) {
             return PROGRESS_NONE
         }
         val pagePercent = (pageIndex + 1) / pagesCount.toFloat()
@@ -1181,5 +1206,40 @@ class ReaderViewModel @Inject constructor(
     } else {
         other.addSuppressed(this)
         other
+    }
+
+    private fun observeMergeRepeatedChapters() {
+        launchJob(Dispatchers.Default) {
+            isMergeRepeatedChapters
+                .collect { useMerge ->
+                    val currentState = readingState.value ?: return@collect
+                    Log.d(LOG_TAG, "isMergeRepeatedChapters changed to $useMerge")
+                    
+                    // Keep only the current chapter's pages in memory, clearing any preloaded next/prev chapters
+                    chaptersLoader.keepOnlyChapter(currentState.chapterId)
+                    
+                    // Re-calculate UI state and content snapshot
+                    content.value = ReaderContent(getSplitPagesSnapshot(), currentState)
+                    notifyStateChanged()
+                }
+        }
+    }
+
+    private fun getReadingChapters(): List<ContentChapter> {
+        val details = mangaDetails.value ?: return emptyList()
+        val contentType = details.toContent().source.getContentType()
+        val useMerge = isMergeRepeatedChapters.value && contentType.isManga()
+        return if (useMerge) {
+            val allBranches = details.chapters.keys.toList()
+            val rawChapters = allBranches.flatMap { details.chapters[it].orEmpty() }
+            rawChapters.mergeRepeated()
+        } else {
+            val branch = selectedBranch.value
+            if (branch != null) {
+                details.chapters[branch].orEmpty()
+            } else {
+                details.allChapters
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new fix for the "merge repeated chapters" feature, which deduplicates chapters with similar metadata across branches and improves chapter navigation and history matching throughout the application. The changes add extension methods for chapter merging, update core reading and navigation logic to use the merged list when enabled, and ensure UI and state management are consistent with this new behavior.

**New chapter merging logic:**

- Added `getMergeKey`, `mergeRepeated`, and `isManga` extension methods to `ContentChapter` and `ContentType` for chapter deduplication and content type checks. (`app/src/main/kotlin/org/skepsun/kototoro/core/model/ContentChapterExt.kt`)

**Reader and navigation logic updates:**

- Updated `ChaptersLoader` and `ReaderViewModel` to use merged chapters for navigation, progress calculation, and state updates when the feature is enabled, including handling for chapter index lookup and history matching with merge keys. (`app/src/main/kotlin/org/skepsun/kototoro/reader/domain/ChaptersLoader.kt`, `app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt`) [[1]](diffhunk://#diff-59cc9d734cad9da186ad8e96832b6d13d96fde7ea7130d22f923fcc11a02655fL41-R72) [[2]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19L590-R610) [[3]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19L1000-R1030) [[4]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19R1210-R1244)

**History and details handling:**

- Updated `HistoryInfo` and details-related logic to support merged chapters for accurate history matching and chapter selection. (`app/src/main/kotlin/org/skepsun/kototoro/details/ui/model/HistoryInfo.kt`, `app/src/main/kotlin/org/skepsun/kototoro/details/ui/DetailsViewModel.kt`, `app/src/main/kotlin/org/skepsun/kototoro/details/ui/ReadButtonDelegate.kt`) [[1]](diffhunk://#diff-c7d9111b1d4aadaa2624a3e6bdef8a125f235d6155e40b08acaad46ad29b0c90R43-R65) [[2]](diffhunk://#diff-d6eab077945cd32567c7203f2c8a9819bfc162d816f80845f436bdaeb9b4786eL3059-R3062) [[3]](diffhunk://#diff-c609c9d79b8cb8c2fbc367cfb9c16c92cf40f05c9cef99226a3ffc90b476e6f6L74-R96)

**State and UI management:**

- Ensured UI state (such as chapter lists, progress, and navigation) consistently reflects the merged chapter list when enabled, and added logic to clear preloaded chapters when the merge setting changes. (`app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt`)

**Codebase maintenance:**

- Added necessary imports and refactored code to support the new merging logic across affected files. [[1]](diffhunk://#diff-c609c9d79b8cb8c2fbc367cfb9c16c92cf40f05c9cef99226a3ffc90b476e6f6R35-R38) [[2]](diffhunk://#diff-c7d9111b1d4aadaa2624a3e6bdef8a125f235d6155e40b08acaad46ad29b0c90R7-R10) [[3]](diffhunk://#diff-59cc9d734cad9da186ad8e96832b6d13d96fde7ea7130d22f923fcc11a02655fR17-R29) [[4]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19R22) [[5]](diffhunk://#diff-3594122c9d59e81c6525b2b5d37b7ad49c0c9080cbd0e7fa29d5a80787d8ec19R74-R78)

These changes collectively improve the user experience when reading series with duplicate or overlapping chapters across branches by providing a cleaner, unified chapter list and ensuring navigation and history features remain reliable.