### PR TITLE
Add absolute chapter resolver for scrobbling

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/scrobbling/common/domain/AbsoluteChapterResolver.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/scrobbling/common/domain/AbsoluteChapterResolver.kt
@@ -1,0 +1,98 @@
+package org.skepsun.kototoro.scrobbling.common.domain
+
+import org.skepsun.kototoro.parsers.model.ContentChapter
+
+internal fun resolveAbsoluteChapterNumber(
+	chapters: List<ContentChapter>,
+	targetChapter: ContentChapter
+): Int {
+	val branchChapters = chapters.filter { it.branch == targetChapter.branch }
+	if (branchChapters.isEmpty()) return 1
+
+	// 1. Determine list direction: ascending (oldest first) vs descending (newest first)
+	var ascendingCount = 0
+	var descendingCount = 0
+	var prevNumForDir: Float? = null
+	for (ch in branchChapters) {
+		val num = ch.number
+		if (num > 0f) {
+			if (prevNumForDir != null) {
+				if (num > prevNumForDir) {
+					ascendingCount++
+				} else if (num < prevNumForDir) {
+					descendingCount++
+				}
+			}
+			prevNumForDir = num
+		}
+	}
+	val isNewestFirst = descendingCount > ascendingCount
+	val chronologicalChapters = if (isNewestFirst) branchChapters.reversed() else branchChapters
+
+	// 2. Compute absolute numbers using season reset detection
+	var seasonOffset = 0f
+	var prevValidNumber = 0f
+	var targetAbsoluteNumber = -1
+
+	fun extractSeason(title: String?, url: String?): Int? {
+		val patterns = listOf(
+			Regex("""\bS(?:eason)?\s*(\d+)\b""", RegexOption.IGNORE_CASE),
+			Regex("""\bPart\s*(\d+)\b""", RegexOption.IGNORE_CASE),
+			Regex("""/s(\d+)(?:[/-]|$)""", RegexOption.IGNORE_CASE),
+			Regex("""[/-]s(\d+)(?:[/-]|$)""", RegexOption.IGNORE_CASE)
+		)
+		title?.let { t ->
+			for (pattern in patterns) {
+				pattern.find(t)?.groupValues?.getOrNull(1)?.toIntOrNull()?.let { return it }
+			}
+		}
+		url?.let { u ->
+			for (pattern in patterns) {
+				pattern.find(u)?.groupValues?.getOrNull(1)?.toIntOrNull()?.let { return it }
+			}
+		}
+		return null
+	}
+
+	for (i in chronologicalChapters.indices) {
+		val ch = chronologicalChapters[i]
+		val chNum = if (ch.number > 0f) ch.number else (prevValidNumber + 1f)
+
+		if (i > 0) {
+			val prevCh = chronologicalChapters[i - 1]
+			val prevChNum = if (prevCh.number > 0f) prevCh.number else prevValidNumber
+
+			val prevSeason = extractSeason(prevCh.title, prevCh.url)
+			val currSeason = extractSeason(ch.title, ch.url)
+
+			val hasExplicitSeasonChange = currSeason != null && prevSeason != null && currSeason > prevSeason && chNum <= prevChNum
+			val hasNumberReset = chNum < prevChNum && chNum <= 5f && (
+				i == chronologicalChapters.size - 1 ||
+				(i + 1 < chronologicalChapters.size &&
+					(chronologicalChapters[i + 1].number.takeIf { it > 0f } ?: (chNum + 1f)) <= prevChNum)
+			)
+
+			if (hasExplicitSeasonChange || hasNumberReset) {
+				seasonOffset += prevChNum
+			}
+		}
+
+		val absoluteNumber = chNum + seasonOffset
+		prevValidNumber = if (ch.number > 0f) ch.number else chNum
+
+		if (ch.id == targetChapter.id) {
+			targetAbsoluteNumber = absoluteNumber.toInt()
+			break
+		}
+	}
+
+	return if (targetAbsoluteNumber > 0) {
+		targetAbsoluteNumber
+	} else {
+		if (targetChapter.number > 0f) {
+			targetChapter.number.toInt()
+		} else {
+			branchChapters.indexOf(targetChapter) + 1
+		}
+	}
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/scrobbling/common/domain/Scrobbler.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/scrobbling/common/domain/Scrobbler.kt
@@ -96,12 +96,7 @@ abstract class Scrobbler(
 		val chapter = checkNotNull(chapters.findById(chapterId)) {
 			"Chapter $chapterId not found in this manga"
 		}
-		val number = if (chapter.number > 0f) {
-			chapter.number.toInt()
-		} else {
-			chapters = chapters.filter { x -> x.branch == chapter.branch }
-			chapters.indexOf(chapter) + 1
-		}
+		val number = resolveAbsoluteChapterNumber(chapters, chapter)
 		val entity = resolveScrobblingEntity(manga.id) ?: return
 		repository.updateRate(entity.id, entity.mangaId, number)
 	}

--- a/app/src/test/kotlin/org/skepsun/kototoro/scrobbling/common/domain/AbsoluteChapterResolverTest.kt
+++ b/app/src/test/kotlin/org/skepsun/kototoro/scrobbling/common/domain/AbsoluteChapterResolverTest.kt
@@ -1,0 +1,100 @@
+package org.skepsun.kototoro.scrobbling.common.domain
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.skepsun.kototoro.core.model.TestContentSource
+import org.skepsun.kototoro.parsers.model.ContentChapter
+
+class AbsoluteChapterResolverTest : StringSpec({
+
+	fun createChapter(
+		id: Long,
+		number: Float,
+		title: String?,
+		branch: String? = "default"
+	): ContentChapter {
+		return ContentChapter(
+			id = id,
+			title = title,
+			number = number,
+			volume = 0,
+			url = "http://example.com/chapter/$id",
+			scanlator = null,
+			uploadDate = 0L,
+			branch = branch,
+			source = TestContentSource
+		)
+	}
+
+	"should resolve target chapter number directly when sequential and no resets" {
+		val ch1 = createChapter(1L, 1f, "Chapter 1")
+		val ch2 = createChapter(2L, 2f, "Chapter 2")
+		val ch3 = createChapter(3L, 3f, "Chapter 3")
+		val chapters = listOf(ch1, ch2, ch3)
+
+		resolveAbsoluteChapterNumber(chapters, ch1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, ch2) shouldBe 2
+		resolveAbsoluteChapterNumber(chapters, ch3) shouldBe 3
+	}
+
+	"should resolve target chapter number when list is in reverse order (newest first)" {
+		val ch1 = createChapter(1L, 1f, "Chapter 1")
+		val ch2 = createChapter(2L, 2f, "Chapter 2")
+		val ch3 = createChapter(3L, 3f, "Chapter 3")
+		val chapters = listOf(ch3, ch2, ch1)
+
+		resolveAbsoluteChapterNumber(chapters, ch1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, ch2) shouldBe 2
+		resolveAbsoluteChapterNumber(chapters, ch3) shouldBe 3
+	}
+
+	"should compute correct offset on numeric reset (Season 1 ends, Season 2 starts at 1)" {
+		val s1c1 = createChapter(1L, 1f, "Chapter 1")
+		val s1c2 = createChapter(2L, 2f, "Chapter 2") // Season 1 ends at 2
+		val s2c1 = createChapter(3L, 1f, "Chapter 1") // Season 2 starts at 1
+		val s2c2 = createChapter(4L, 2f, "Chapter 2")
+		val chapters = listOf(s1c1, s1c2, s2c1, s2c2)
+
+		resolveAbsoluteChapterNumber(chapters, s1c1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, s1c2) shouldBe 2
+		resolveAbsoluteChapterNumber(chapters, s2c1) shouldBe 3
+		resolveAbsoluteChapterNumber(chapters, s2c2) shouldBe 4
+	}
+
+	"should compute correct offset on explicit season title change" {
+		val s1c1 = createChapter(1L, 1f, "S1 - Chapter 1")
+		val s1c2 = createChapter(2L, 82f, "S1 - Chapter 82")
+		val s2c1 = createChapter(3L, 1f, "S2 - Chapter 1")
+		val s2c2 = createChapter(4L, 2f, "S2 - Chapter 2")
+		val chapters = listOf(s1c1, s1c2, s2c1, s2c2)
+
+		resolveAbsoluteChapterNumber(chapters, s1c1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, s1c2) shouldBe 82
+		resolveAbsoluteChapterNumber(chapters, s2c1) shouldBe 83
+		resolveAbsoluteChapterNumber(chapters, s2c2) shouldBe 84
+	}
+
+	"should not trigger false reset on out-of-order bonus chapter" {
+		val ch1 = createChapter(1L, 1f, "Chapter 1")
+		val ch2 = createChapter(2L, 2f, "Chapter 2")
+		val chBonus = createChapter(3L, 1.5f, "Chapter 1.5") // Jumps back from 2 to 1.5, but next is 3
+		val ch3 = createChapter(4L, 3f, "Chapter 3")
+		val chapters = listOf(ch1, ch2, chBonus, ch3)
+
+		resolveAbsoluteChapterNumber(chapters, ch1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, ch2) shouldBe 2
+		resolveAbsoluteChapterNumber(chapters, chBonus) shouldBe 1 // toInt() of 1.5f is 1
+		resolveAbsoluteChapterNumber(chapters, ch3) shouldBe 3
+	}
+
+	"should resolve using simple index fallback if chapter numbers are 0 or missing" {
+		val ch1 = createChapter(1L, 0f, "Intro")
+		val ch2 = createChapter(2L, 0f, "Middle")
+		val ch3 = createChapter(3L, 0f, "Outro")
+		val chapters = listOf(ch1, ch2, ch3)
+
+		resolveAbsoluteChapterNumber(chapters, ch1) shouldBe 1
+		resolveAbsoluteChapterNumber(chapters, ch2) shouldBe 2
+		resolveAbsoluteChapterNumber(chapters, ch3) shouldBe 3
+	}
+})


### PR DESCRIPTION
Extract chapter-number resolution into a dedicated resolver and use it in `Scrobbler` when updating progress. The new logic handles branch filtering, newest-first chapter lists, season/part resets, and fallback behavior for missing numbers so scrobbling reports consistent absolute chapter progress. Added unit tests covering sequential order, reverse order, numeric and explicit season resets, bonus chapter ordering, and zero-number fallback.