### PR TITLE
feat: implement Android dynamic shortcuts support for manga and content

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/nav/AppRouter.kt
@@ -478,7 +478,16 @@ class AppRouter private constructor(
 		// Intercept video sources when ReaderIntent carries a Content extra and route accordingly
 		runCatching {
 			val parcelable = activityIntent.getParcelableExtraCompat<ParcelableContent>(KEY_MANGA)
-			val manga = parcelable?.manga
+			val manga = parcelable?.manga ?: run {
+				val contentIntent = ContentIntent(activityIntent)
+				val mangaId = contentIntent.mangaId
+				if (mangaId != ContentIntent.ID_NONE) {
+					kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
+						contentDataRepository.findDisplayContentById(mangaId, withChapters = false)
+							?: contentDataRepository.findContentById(mangaId, withChapters = false)
+					}
+				} else null
+			}
 			if (manga != null) {
                 // 瀵硅棰戝唴瀹瑰拰EPUB鍐呭锛氫紶?ReaderState锛屼紭鍏堜娇鐢ㄥ巻鍙茶褰曚腑鐨勭姸?
                 val source = manga.source.unwrap()

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/os/AppShortcutManager.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/os/AppShortcutManager.kt
@@ -196,7 +196,7 @@ class AppShortcutManager @Inject constructor(
 			.setLongLived(true)
 			.setIntent(
 				ReaderIntent.Builder(context)
-					.mangaId(currentManga.id)
+					.manga(currentManga)
 					.build()
 					.intent,
 			).build()

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderActivity.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderActivity.kt
@@ -48,7 +48,18 @@ import org.skepsun.kototoro.R
 import org.skepsun.kototoro.core.exceptions.CloudFlareProtectedException
 import org.skepsun.kototoro.core.exceptions.resolve.DialogErrorObserver
 import org.skepsun.kototoro.core.exceptions.resolve.SnackbarErrorObserver
+import kotlinx.coroutines.runBlocking
+import org.skepsun.kototoro.core.model.getContentType
+import org.skepsun.kototoro.core.model.unwrap
+import org.skepsun.kototoro.core.model.looksLikeLocalVideoContent
+import org.skepsun.kototoro.core.model.parcelable.ParcelableContent
 import org.skepsun.kototoro.core.nav.AppRouter
+import org.skepsun.kototoro.core.nav.ContentIntent
+import org.skepsun.kototoro.core.nav.ReaderIntent
+import org.skepsun.kototoro.core.parser.ContentDataRepository
+import org.skepsun.kototoro.core.util.ext.getParcelableExtraCompat
+import org.skepsun.kototoro.parsers.model.Content
+import org.skepsun.kototoro.parsers.model.ContentType
 import org.skepsun.kototoro.core.nav.router
 import org.skepsun.kototoro.core.prefs.AppSettings
 import org.skepsun.kototoro.core.util.FoldableUtils
@@ -125,6 +136,9 @@ class ReaderActivity :
     @Inject
     lateinit var spaceSwitcherDelegate: SpaceSwitcherDelegate
 
+    @Inject
+    lateinit var contentDataRepository: ContentDataRepository
+
     private val idlingDetector = IdlingDetector(TimeUnit.SECONDS.toMillis(10), this)
 
     private val viewModel: ReaderViewModel by viewModels()
@@ -154,8 +168,48 @@ class ReaderActivity :
         settings.isReaderTranslationShowTranslated = false
     }
 
+    private fun checkAndRedirectMedia(intent: Intent): Boolean {
+        val parcelable = intent.getParcelableExtraCompat<ParcelableContent>(AppRouter.KEY_MANGA)
+        var manga: Content? = parcelable?.manga
+        if (manga == null) {
+            val contentIntent = ContentIntent(intent)
+            val mangaId = contentIntent.mangaId
+            if (mangaId != ContentIntent.ID_NONE) {
+                manga = runBlocking(Dispatchers.IO) {
+                    contentDataRepository.findDisplayContentById(mangaId, withChapters = false)
+                        ?: contentDataRepository.findContentById(mangaId, withChapters = false)
+                }
+            }
+        }
+        if (manga != null) {
+            val source = manga.source.unwrap()
+            val contentType = if (manga.looksLikeLocalVideoContent()) {
+                ContentType.VIDEO
+            } else {
+                source.getContentType()
+            }
+            if (contentType == ContentType.NOVEL || contentType == ContentType.HENTAI_NOVEL ||
+                contentType == ContentType.VIDEO || contentType == ContentType.HENTAI_VIDEO
+            ) {
+                val state = intent.getParcelableExtraCompat<ReaderState>(ReaderIntent.EXTRA_STATE)
+                AppRouter(this).openReader(
+                    ReaderIntent.Builder(this)
+                        .manga(manga)
+                        .state(state)
+                        .build(),
+                )
+                finish()
+                return true
+            }
+        }
+        return false
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (checkAndRedirectMedia(intent)) {
+            return
+        }
         if (savedInstanceState == null) {
             resetTranslationSession()
         } else {
@@ -254,6 +308,16 @@ class ReaderActivity :
             } else {
                 errorSnackbar.emit(error)
             }
+        }
+        viewModel.onRedirectToReader.observeEvent(this) { manga ->
+            val state = intent.getParcelableExtraCompat<ReaderState>(ReaderIntent.EXTRA_STATE)
+            AppRouter(this).openReader(
+                ReaderIntent.Builder(this)
+                    .manga(manga)
+                    .state(state)
+                    .build(),
+            )
+            finish()
         }
         viewModel.readerMode.observe(this, Lifecycle.State.STARTED, this::onInitReader)
         viewModel.onPageSaved.observeEvent(this, PagesSavedObserver(viewBinding.container))

--- a/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/reader/ui/ReaderViewModel.kt
@@ -77,6 +77,8 @@ import org.skepsun.kototoro.core.model.getMergeKey
 import org.skepsun.kototoro.core.model.mergeRepeated
 import org.skepsun.kototoro.core.model.isManga
 import org.skepsun.kototoro.core.model.getContentType
+import org.skepsun.kototoro.core.model.looksLikeLocalVideoContent
+import org.skepsun.kototoro.parsers.model.ContentType
 import org.skepsun.kototoro.reader.domain.PageLoader
 import org.skepsun.kototoro.reader.domain.ReaderPageEnhancementController
 import org.skepsun.kototoro.reader.domain.TranslationLayerState
@@ -165,6 +167,7 @@ class ReaderViewModel @Inject constructor(
     val onLoadingError = MutableEventFlow<Throwable>()
     val onShowToast = MutableEventFlow<Int>()
     val onAskNsfwIncognito = MutableEventFlow<Unit>()
+    val onRedirectToReader = MutableEventFlow<Content>()
     val uiState = MutableStateFlow<ReaderUiState?>(null)
     val targetPagePosition = MutableStateFlow<Int?>(null)
     val translationLayerState = MutableStateFlow(TranslationLayerState.IDLE)
@@ -827,6 +830,17 @@ class ReaderViewModel @Inject constructor(
                         }
                         chaptersLoader.init(details)
                         val manga = details.toContent()
+                        val contentType = if (manga.looksLikeLocalVideoContent()) {
+                            ContentType.VIDEO
+                        } else {
+                            manga.source.getContentType()
+                        }
+                        if (contentType == ContentType.NOVEL || contentType == ContentType.HENTAI_NOVEL ||
+                            contentType == ContentType.VIDEO || contentType == ContentType.HENTAI_VIDEO
+                        ) {
+                            onRedirectToReader.call(manga)
+                            return@collect
+                        }
                         // obtain state
                         if (readingState.value == null) {
                             val newState = getStateFromIntent(manga)


### PR DESCRIPTION
Summary of Accomplishments
Early Redirection in ReaderActivity: Added checkAndRedirectMedia() in onCreate() before UI/view model setup. If a widget item or shortcut launches ReaderActivity for a light/web novel or video content, it immediately launches NovelReaderActivity or VideoPlayerActivity via AppRouter and finishes ReaderActivity.

Asynchronous Fallback in ReaderViewModel: Added an onRedirectToReader event flow so if details are fetched asynchronously from the network/database for an ID-only intent, ReaderActivity redirects cleanly upon receiving the non-manga content details.

Enhanced AppRouter & AppShortcutManager: AppRouter.openReader(ReaderIntent) now resolves missing manga objects by ID from ContentDataRepository.

AppShortcutManager now embeds full Content metadata into generated shortcut intents so media type is detected immediately upon opening shortcuts.

Verification: Executed ./gradlew :app:compileDebugKotlin --no-daemon and verified that compilation built cleanly (BUILD SUCCESSFUL).