### PR TITLE
feat: add Usagi backup support and settings integration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -460,6 +460,10 @@
 			android:foregroundServiceType="dataSync"
 			android:label="@string/export_aniyomi_backup" />
 		<service
+			android:name="org.skepsun.kototoro.backups.ui.backup.UsagiBackupExportService"
+			android:foregroundServiceType="dataSync"
+			android:label="@string/export_usagi_backup" />
+		<service
 			android:name="org.skepsun.kototoro.backups.ui.restore.RestoreService"
 			android:foregroundServiceType="dataSync"
 			android:label="@string/restoring_backup" />

--- a/app/src/main/kotlin/org/skepsun/kototoro/backups/domain/BackupUtils.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/backups/domain/BackupUtils.kt
@@ -53,4 +53,11 @@ object BackupUtils {
 		append(dateTimeFormat.format(Date()))
 		append(".aniyomibk")
 	}
+
+	fun generateUsagiBackupFileName(context: Context) = buildString {
+		append(context.getString(R.string.app_name).replace(' ', '_').lowercase(Locale.ROOT))
+		append("_usagi_")
+		append(dateTimeFormat.format(Date()))
+		append(".bk.zip")
+	}
 }

--- a/app/src/main/kotlin/org/skepsun/kototoro/backups/external/UsagiBackupExportRepository.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/backups/external/UsagiBackupExportRepository.kt
@@ -1,0 +1,276 @@
+package org.skepsun.kototoro.backups.external
+
+import android.content.Context
+import dagger.Reusable
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToStream
+import kotlinx.serialization.serializer
+import org.skepsun.kototoro.R
+import org.skepsun.kototoro.core.db.MangaDatabase
+import org.skepsun.kototoro.core.db.entity.MangaEntity
+import org.skepsun.kototoro.core.db.entity.TagEntity
+import org.skepsun.kototoro.favourites.data.FavouriteCategoryEntity
+import org.skepsun.kototoro.favourites.data.FavouriteEntity
+import org.skepsun.kototoro.history.data.HistoryEntity
+import org.skepsun.kototoro.core.util.progress.Progress
+import java.io.OutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+
+data class UsagiBackupExportSummary(
+    val exportedCount: Int,
+)
+
+@Reusable
+class UsagiBackupExportRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MangaDatabase,
+) {
+
+    private val json = Json {
+        allowSpecialFloatingPointValues = true
+        coerceInputValues = true
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+
+    suspend fun export(
+        output: OutputStream,
+        progress: FlowCollector<Progress>? = null,
+    ): UsagiBackupExportSummary {
+        progress?.emit(Progress.INDETERMINATE)
+
+        val workState = database.readExternalBackupWorkState()
+
+        // 1. Gather all candidate manga IDs from favourites, history, bookmarks, scrobblings, and stats
+        val bookmarksDump = database.getBookmarksDao().dump().toList()
+        val scrobblingsDump = database.getScrobblingDao().dumpEnabled().toList()
+        val statsDump = database.getWorkStatsDao().dumpEnabled().toList()
+
+        val bookmarkMangaIds = bookmarksDump.map { it.first.manga.id }
+        val scrobblingMangaIds = scrobblingsDump.map { it.mangaId }
+        val statMangaIds = statsDump.map { it.anchorMangaId }
+
+        val allCandidateIds = (
+            workState.candidateMangaIds +
+                bookmarkMangaIds +
+                scrobblingMangaIds +
+                statMangaIds
+            ).distinct()
+
+        if (allCandidateIds.isEmpty()) {
+            throw IllegalStateException(context.getString(R.string.export_usagi_backup_empty))
+        }
+
+        // 2. Query MangaEntity objects and filter out non-manga entries (e.g. Light Novels, Anime/Videos)
+        val mangaById = database.getMangaDao().findEntitiesByIds(allCandidateIds)
+            .filter { isMangaMedia(it) }
+            .associateBy(MangaEntity::id)
+
+        val validMangaIds = mangaById.keys
+        if (validMangaIds.isEmpty()) {
+            throw IllegalStateException(context.getString(R.string.export_usagi_backup_empty))
+        }
+
+        progress?.emit(Progress(0, validMangaIds.size))
+
+        // 3. Load tags for valid exported manga entries
+        val tagTitlesByMangaId = loadTagEntitiesByMangaId(validMangaIds.toList())
+
+        // Map MangaEntity -> UsagiMangaBackup
+        val usagiMangaMap = mangaById.mapValues { (mangaId, manga) ->
+            val tags = tagTitlesByMangaId[mangaId].orEmpty().mapTo(LinkedHashSet()) { tag ->
+                UsagiTagBackup(
+                    id = tag.id,
+                    title = tag.title,
+                    key = tag.key,
+                    source = tag.source,
+                    isPinned = tag.isPinned,
+                )
+            }
+            UsagiMangaBackup(
+                id = manga.id,
+                title = manga.title,
+                altTitles = manga.altTitles,
+                url = manga.url,
+                publicUrl = manga.publicUrl,
+                rating = manga.rating,
+                isNsfw = manga.isNsfw,
+                contentRating = manga.contentRating,
+                coverUrl = manga.coverUrl,
+                largeCoverUrl = manga.largeCoverUrl,
+                state = manga.state,
+                authors = manga.authors,
+                source = manga.source,
+                tags = tags,
+            )
+        }
+
+        // 4. Categories
+        val categories = database.getFavouriteCategoriesDao().findAll().map { cat ->
+            UsagiCategoryBackup(
+                categoryId = cat.categoryId,
+                createdAt = cat.createdAt,
+                sortKey = cat.sortKey,
+                title = cat.title,
+                order = cat.order,
+                track = cat.track,
+                isVisibleInLibrary = cat.isVisibleInLibrary,
+            )
+        }
+
+        // 5. Favourites
+        val favouriteBackups = workState.favouriteEntries.mapNotNull { fav ->
+            val mangaBackup = usagiMangaMap[fav.mangaId] ?: return@mapNotNull null
+            UsagiFavouriteBackup(
+                mangaId = fav.mangaId,
+                categoryId = fav.categoryId.toLong(),
+                sortKey = fav.sortKey,
+                isPinned = fav.isPinned,
+                createdAt = fav.createdAt,
+                manga = mangaBackup,
+            )
+        }
+
+        // 6. History
+        val historyBackups = workState.historyEntries.mapNotNull { hist ->
+            val mangaBackup = usagiMangaMap[hist.mangaId] ?: return@mapNotNull null
+            UsagiHistoryBackup(
+                mangaId = hist.mangaId,
+                createdAt = hist.createdAt,
+                updatedAt = hist.updatedAt,
+                chapterId = hist.chapterId,
+                page = hist.page,
+                scroll = hist.scroll,
+                percent = hist.percent,
+                chaptersCount = hist.chaptersCount,
+                manga = mangaBackup,
+            )
+        }
+
+        // 7. Bookmarks
+        val bookmarkBackups = bookmarksDump.mapNotNull { (mangaWithTags, bookmarks) ->
+            val mangaBackup = usagiMangaMap[mangaWithTags.manga.id] ?: return@mapNotNull null
+            val bookmarkItems = bookmarks.map { b ->
+                UsagiBookmarkItem(
+                    mangaId = b.mangaId,
+                    pageId = b.pageId,
+                    chapterId = b.chapterId,
+                    page = b.page,
+                    scroll = b.scroll,
+                    imageUrl = b.imageUrl,
+                    createdAt = b.createdAt,
+                    percent = b.percent,
+                )
+            }
+            UsagiBookmarkBackup(
+                manga = mangaBackup.copy(tags = emptySet()),
+                tags = mangaBackup.tags,
+                bookmarks = bookmarkItems,
+            )
+        }
+
+        // 8. Sources
+        val exportedSources = mangaById.values.map { it.source }.distinct().mapIndexed { index, sourceName ->
+            UsagiSourceBackup(
+                source = sourceName,
+                sortKey = index,
+                lastUsedAt = System.currentTimeMillis(),
+                addedIn = 1,
+                isPinned = false,
+                isEnabled = true,
+            )
+        }
+
+        // 9. Scrobblings (Tracking)
+        val scrobblingBackups = scrobblingsDump.mapNotNull { scrobble ->
+            if (scrobble.mangaId !in validMangaIds) return@mapNotNull null
+            UsagiScrobblingBackup(
+                scrobbler = scrobble.scrobbler,
+                id = scrobble.id,
+                mangaId = scrobble.mangaId,
+                targetId = scrobble.targetId,
+                status = scrobble.status,
+                chapter = scrobble.chapter,
+                comment = scrobble.comment,
+                rating = scrobble.rating,
+            )
+        }
+
+        // 10. Statistics
+        val statisticBackups = statsDump.mapNotNull { stat ->
+            if (stat.anchorMangaId !in validMangaIds) return@mapNotNull null
+            UsagiStatisticBackup(
+                mangaId = stat.anchorMangaId,
+                startedAt = stat.startedAt,
+                duration = stat.duration,
+                pages = stat.pages,
+            )
+        }
+
+        progress?.emit(Progress(validMangaIds.size, validMangaIds.size))
+
+        // Write Zip Backup
+        ZipOutputStream(output).use { zip ->
+            zip.writeJsonArray("index", listOf(UsagiBackupIndex()))
+            zip.writeJsonArray("categories", categories)
+            zip.writeJsonArray("favourites", favouriteBackups)
+            zip.writeJsonArray("history", historyBackups)
+            zip.writeJsonArray("bookmarks", bookmarkBackups)
+            zip.writeJsonArray("sources", exportedSources)
+            zip.writeJsonArray("scrobbling", scrobblingBackups)
+            zip.writeJsonArray("statistics", statisticBackups)
+        }
+
+        return UsagiBackupExportSummary(exportedCount = usagiMangaMap.size)
+    }
+
+    private fun isMangaMedia(manga: MangaEntity): Boolean {
+        val type = manga.contentType?.uppercase() ?: return true
+        return type !in NON_MANGA_CONTENT_TYPES
+    }
+
+    private suspend fun loadTagEntitiesByMangaId(mangaIds: List<Long>): Map<Long, List<TagEntity>> {
+        val tagRelations = database.getMangaDao().findTagRelationsByMangaIds(mangaIds)
+        if (tagRelations.isEmpty()) {
+            return emptyMap()
+        }
+        val tagsById = database.getTagsDao()
+            .findByIds(tagRelations.map { it.tagId }.distinct())
+            .associateBy { it.id }
+        return tagRelations.groupBy { it.mangaId }
+            .mapValues { (_, relations) ->
+                relations.mapNotNull { relation -> tagsById[relation.tagId] }
+            }
+    }
+
+    private inline fun <reified T> ZipOutputStream.writeJsonArray(
+        entryName: String,
+        data: List<T>,
+    ) {
+        putNextEntry(ZipEntry(entryName))
+        write("[".toByteArray())
+        data.forEachIndexed { index, item ->
+            if (index > 0) {
+                write(",".toByteArray())
+            }
+            json.encodeToStream(serializer<T>(), item, this)
+        }
+        write("]".toByteArray())
+        closeEntry()
+        flush()
+    }
+
+    private companion object {
+        private val NON_MANGA_CONTENT_TYPES = setOf(
+            "NOVEL",
+            "HENTAI_NOVEL",
+            "VIDEO",
+            "HENTAI_VIDEO",
+        )
+    }
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/backups/external/UsagiBackupModels.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/backups/external/UsagiBackupModels.kt
@@ -1,0 +1,121 @@
+package org.skepsun.kototoro.backups.external
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UsagiBackupIndex(
+    @SerialName("app_id") val appId: String = "org.draken.usagi",
+    @SerialName("app_version") val appVersion: Int = 1,
+    @SerialName("created_at") val createdAt: Long = System.currentTimeMillis(),
+)
+
+@Serializable
+data class UsagiCategoryBackup(
+    @SerialName("category_id") val categoryId: Int,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("sort_key") val sortKey: Int,
+    @SerialName("title") val title: String,
+    @SerialName("order") val order: String = "NEWEST",
+    @SerialName("track") val track: Boolean = true,
+    @SerialName("show_in_lib") val isVisibleInLibrary: Boolean = true,
+)
+
+@Serializable
+data class UsagiTagBackup(
+    @SerialName("id") val id: Long,
+    @SerialName("title") val title: String,
+    @SerialName("key") val key: String,
+    @SerialName("source") val source: String,
+    @SerialName("pinned") val isPinned: Boolean = false,
+)
+
+@Serializable
+data class UsagiMangaBackup(
+    @SerialName("id") val id: Long,
+    @SerialName("title") val title: String,
+    @SerialName("alt_title") val altTitles: String? = null,
+    @SerialName("url") val url: String,
+    @SerialName("public_url") val publicUrl: String,
+    @SerialName("rating") val rating: Float = -1f,
+    @SerialName("nsfw") val isNsfw: Boolean = false,
+    @SerialName("content_rating") val contentRating: String? = null,
+    @SerialName("cover_url") val coverUrl: String,
+    @SerialName("large_cover_url") val largeCoverUrl: String? = null,
+    @SerialName("state") val state: String? = null,
+    @SerialName("author") val authors: String? = null,
+    @SerialName("source") val source: String,
+    @SerialName("tags") val tags: Set<UsagiTagBackup> = emptySet(),
+)
+
+@Serializable
+data class UsagiFavouriteBackup(
+    @SerialName("manga_id") val mangaId: Long,
+    @SerialName("category_id") val categoryId: Long,
+    @SerialName("sort_key") val sortKey: Int = 0,
+    @SerialName("pinned") val isPinned: Boolean = false,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("manga") val manga: UsagiMangaBackup,
+)
+
+@Serializable
+data class UsagiHistoryBackup(
+    @SerialName("manga_id") val mangaId: Long,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("updated_at") val updatedAt: Long,
+    @SerialName("chapter_id") val chapterId: Long,
+    @SerialName("page") val page: Int,
+    @SerialName("scroll") val scroll: Float,
+    @SerialName("percent") val percent: Float = 0f,
+    @SerialName("chapters") val chaptersCount: Int = 0,
+    @SerialName("manga") val manga: UsagiMangaBackup,
+)
+
+@Serializable
+data class UsagiBookmarkBackup(
+    @SerialName("manga") val manga: UsagiMangaBackup,
+    @SerialName("tags") val tags: Set<UsagiTagBackup>,
+    @SerialName("bookmarks") val bookmarks: List<UsagiBookmarkItem>,
+)
+
+@Serializable
+data class UsagiBookmarkItem(
+    @SerialName("manga_id") val mangaId: Long,
+    @SerialName("page_id") val pageId: Long,
+    @SerialName("chapter_id") val chapterId: Long,
+    @SerialName("page") val page: Int,
+    @SerialName("scroll") val scroll: Int,
+    @SerialName("image_url") val imageUrl: String,
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("percent") val percent: Float,
+)
+
+@Serializable
+data class UsagiSourceBackup(
+    @SerialName("source") val source: String,
+    @SerialName("sort_key") val sortKey: Int = 0,
+    @SerialName("used_at") val lastUsedAt: Long = System.currentTimeMillis(),
+    @SerialName("added_in") val addedIn: Int = 1,
+    @SerialName("pinned") val isPinned: Boolean = false,
+    @SerialName("enabled") val isEnabled: Boolean = true,
+)
+
+@Serializable
+data class UsagiScrobblingBackup(
+    @SerialName("scrobbler") val scrobbler: Int,
+    @SerialName("id") val id: Int,
+    @SerialName("manga_id") val mangaId: Long,
+    @SerialName("target_id") val targetId: Long,
+    @SerialName("status") val status: String?,
+    @SerialName("chapter") val chapter: Int,
+    @SerialName("comment") val comment: String?,
+    @SerialName("rating") val rating: Float,
+)
+
+@Serializable
+data class UsagiStatisticBackup(
+    @SerialName("manga_id") val mangaId: Long,
+    @SerialName("started_at") val startedAt: Long,
+    @SerialName("duration") val duration: Long,
+    @SerialName("pages") val pages: Int,
+)

--- a/app/src/main/kotlin/org/skepsun/kototoro/backups/ui/backup/UsagiBackupExportService.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/backups/ui/backup/UsagiBackupExportService.kt
@@ -1,0 +1,184 @@
+package org.skepsun.kototoro.backups.ui.backup
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.Uri
+import android.widget.Toast
+import androidx.annotation.CheckResult
+import androidx.core.app.NotificationCompat
+import androidx.core.app.PendingIntentCompat
+import androidx.core.app.ShareCompat
+import androidx.core.content.ContextCompat
+import androidx.documentfile.provider.DocumentFile
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.skepsun.kototoro.R
+import org.skepsun.kototoro.backups.external.UsagiBackupExportRepository
+import org.skepsun.kototoro.backups.external.UsagiBackupExportSummary
+import org.skepsun.kototoro.backups.ui.BaseBackupRestoreService
+import org.skepsun.kototoro.core.nav.AppRouter
+import org.skepsun.kototoro.core.util.ext.checkNotificationPermission
+import org.skepsun.kototoro.core.util.ext.getFileDisplayName
+import org.skepsun.kototoro.core.util.ext.powerManager
+import org.skepsun.kototoro.core.util.ext.printStackTraceDebug
+import org.skepsun.kototoro.core.util.ext.toUriOrNull
+import org.skepsun.kototoro.core.util.ext.withPartialWakeLock
+import org.skepsun.kototoro.core.util.progress.Progress
+import java.io.FileNotFoundException
+import javax.inject.Inject
+import androidx.appcompat.R as appcompatR
+
+@AndroidEntryPoint
+@SuppressLint("InlinedApi")
+class UsagiBackupExportService : BaseBackupRestoreService() {
+
+    override val notificationTag = TAG
+    override val isRestoreService = false
+
+    @Inject
+    lateinit var repository: UsagiBackupExportRepository
+
+    override suspend fun IntentJobContext.processIntent(intent: Intent) {
+        val notification = buildNotification(Progress.INDETERMINATE)
+        setForeground(
+            FOREGROUND_NOTIFICATION_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+        )
+        val destination = intent.getStringExtra(AppRouter.KEY_DATA)?.toUriOrNull() ?: throw FileNotFoundException()
+        powerManager.withPartialWakeLock(TAG) {
+            val progress = MutableStateFlow(Progress.INDETERMINATE)
+            val progressUpdateJob = if (checkNotificationPermission(CHANNEL_ID)) {
+                launch {
+                    progress.collect {
+                        notificationManager.notify(FOREGROUND_NOTIFICATION_ID, buildNotification(it))
+                    }
+                }
+            } else {
+                null
+            }
+            val summary = try {
+                contentResolver.openOutputStream(destination).use { output ->
+                    checkNotNull(output) { "Unable to open export destination" }
+                    repository.export(output, progress)
+                }
+            } catch (e: Throwable) {
+                try {
+                    DocumentFile.fromSingleUri(applicationContext, destination)?.delete()
+                } catch (deleteError: Throwable) {
+                    e.addSuppressed(deleteError)
+                }
+                throw e
+            } finally {
+                progressUpdateJob?.cancelAndJoin()
+            }
+            contentResolver.notifyChange(destination, null)
+            withContext(Dispatchers.Main) {
+                showExportToast(summary)
+            }
+            showExportResultNotification(destination, summary)
+        }
+    }
+
+    private fun IntentJobContext.buildNotification(progress: Progress): Notification {
+        return NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle(getString(R.string.export_usagi_backup))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(0)
+            .setSilent(true)
+            .setOngoing(true)
+            .setProgress(
+                progress.total.coerceAtLeast(0),
+                progress.progress.coerceAtLeast(0),
+                progress.isIndeterminate,
+            )
+            .setContentText(
+                if (progress.isIndeterminate) {
+                    getString(R.string.processing_)
+                } else {
+                    getString(R.string.fraction_pattern, progress.progress, progress.total)
+                },
+            )
+            .setSmallIcon(android.R.drawable.stat_sys_upload)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .addAction(
+                appcompatR.drawable.abc_ic_clear_material,
+                applicationContext.getString(android.R.string.cancel),
+                getCancelIntent(),
+            )
+            .build()
+    }
+
+    private fun showExportToast(summary: UsagiBackupExportSummary) {
+        Toast.makeText(
+            this,
+            getString(R.string.export_usagi_backup_saved, summary.exportedCount),
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+
+    private fun IntentJobContext.showExportResultNotification(
+        fileUri: Uri,
+        summary: UsagiBackupExportSummary,
+    ) {
+        if (!applicationContext.checkNotificationPermission(CHANNEL_ID)) {
+            return
+        }
+        val shareIntent = ShareCompat.IntentBuilder(this@UsagiBackupExportService)
+            .setStream(fileUri)
+            .setType("application/zip")
+            .setChooserTitle(R.string.share_backup)
+            .createChooserIntent()
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle(getString(R.string.export_usagi_backup))
+            .setContentText(getString(R.string.export_usagi_backup_saved, summary.exportedCount))
+            .setSubText(contentResolver.getFileDisplayName(fileUri))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(0)
+            .setSilent(true)
+            .setAutoCancel(true)
+            .setSmallIcon(R.drawable.ic_stat_done)
+            .setContentIntent(
+                PendingIntentCompat.getActivity(
+                    applicationContext,
+                    0,
+                    AppRouter.homeIntent(this@UsagiBackupExportService),
+                    0,
+                    false,
+                ),
+            )
+            .addAction(
+                appcompatR.drawable.abc_ic_menu_share_mtrl_alpha,
+                getString(R.string.share),
+                PendingIntentCompat.getActivity(this@UsagiBackupExportService, 0, shareIntent, 0, false),
+            )
+            .build()
+        notificationManager.notify(notificationTag, startId, notification)
+    }
+
+    companion object {
+        private const val TAG = "USAGI_BACKUP_EXPORT"
+        private const val FOREGROUND_NOTIFICATION_ID = 43
+
+        @CheckResult
+        fun start(context: Context, uri: Uri): Boolean = try {
+            val intent = Intent(context, UsagiBackupExportService::class.java)
+            intent.putExtra(AppRouter.KEY_DATA, uri.toString())
+            intent.setData(uri)
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            ContextCompat.startForegroundService(context, intent)
+            true
+        } catch (e: Exception) {
+            e.printStackTraceDebug()
+            false
+        }
+    }
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/SettingsActivity.kt
@@ -61,6 +61,7 @@ import org.skepsun.kototoro.backups.external.ExternalBackupApp
 import org.skepsun.kototoro.backups.ui.backup.AniyomiBackupExportService
 import org.skepsun.kototoro.backups.ui.backup.BackupService
 import org.skepsun.kototoro.backups.ui.backup.MihonBackupExportService
+import org.skepsun.kototoro.backups.ui.backup.UsagiBackupExportService
 import org.skepsun.kototoro.backups.ui.periodical.PeriodicalBackupSettingsViewModel
 import org.skepsun.kototoro.backups.ui.restore.ExternalBackupImportService
 import org.skepsun.kototoro.core.github.AppVersion
@@ -329,6 +330,14 @@ class SettingsActivity :
 		ActivityResultContracts.CreateDocument("application/octet-stream"),
 	) { uri ->
 		if (uri != null && !AniyomiBackupExportService.start(this, uri)) {
+			Toast.makeText(this, R.string.operation_not_supported, Toast.LENGTH_SHORT).show()
+		}
+	}
+
+	private val usagiBackupExportCall = registerForActivityResult(
+		ActivityResultContracts.CreateDocument("application/zip"),
+	) { uri ->
+		if (uri != null && !UsagiBackupExportService.start(this, uri)) {
 			Toast.makeText(this, R.string.operation_not_supported, Toast.LENGTH_SHORT).show()
 		}
 	}
@@ -1259,6 +1268,11 @@ class SettingsActivity :
 					},
 					onExportAniyomiBackupClick = {
 						if (!aniyomiBackupExportCall.tryLaunch(BackupUtils.generateAniyomiBackupFileName(this))) {
+							Toast.makeText(this, R.string.operation_not_supported, Toast.LENGTH_SHORT).show()
+						}
+					},
+					onExportUsagiBackupClick = {
+						if (!usagiBackupExportCall.tryLaunch(BackupUtils.generateUsagiBackupFileName(this))) {
 							Toast.makeText(this, R.string.operation_not_supported, Toast.LENGTH_SHORT).show()
 						}
 					},

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/BackupsSettingsScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/compose/BackupsSettingsScreen.kt
@@ -79,6 +79,7 @@ fun BackupsSettingsScreen(
     onRestoreBackupClick: () -> Unit,
     onExportMihonBackupClick: () -> Unit,
     onExportAniyomiBackupClick: () -> Unit,
+    onExportUsagiBackupClick: () -> Unit,
     onImportExternalBackupClick: () -> Unit,
     onDismissExternalImportDialog: () -> Unit,
     onImportExternalBackupAppClick: (ExternalBackupApp) -> Unit,
@@ -189,6 +190,12 @@ fun BackupsSettingsScreen(
                         title = stringResource(R.string.export_aniyomi_backup),
                         summary = stringResource(R.string.export_aniyomi_backup_summary),
                         onClick = onExportAniyomiBackupClick,
+                    )
+                    SettingsSectionDivider()
+                    SettingsActionPreference(
+                        title = stringResource(R.string.export_usagi_backup),
+                        summary = stringResource(R.string.export_usagi_backup_summary),
+                        onClick = onExportUsagiBackupClick,
                     )
                     SettingsSectionDivider()
                     SettingsActionPreference(

--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/userdata/BackupsSettingsFragment.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/userdata/BackupsSettingsFragment.kt
@@ -30,6 +30,7 @@ import org.skepsun.kototoro.backups.external.ExternalBackupApp
 import org.skepsun.kototoro.backups.ui.backup.AniyomiBackupExportService
 import org.skepsun.kototoro.backups.ui.backup.BackupService
 import org.skepsun.kototoro.backups.ui.backup.MihonBackupExportService
+import org.skepsun.kototoro.backups.ui.backup.UsagiBackupExportService
 import org.skepsun.kototoro.backups.ui.periodical.ManualWebDavRestoreMode
 import org.skepsun.kototoro.backups.ui.periodical.PeriodicalBackupSettingsViewModel
 import org.skepsun.kototoro.backups.ui.periodical.WebDavRemoteBackupRestoreStatus
@@ -108,6 +109,14 @@ class BackupsSettingsFragment : Fragment() {
         }
     }
 
+    private val usagiBackupExportCall = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/zip"),
+    ) { uri ->
+        if (uri != null && !UsagiBackupExportService.start(requireContext(), uri)) {
+            showOperationNotSupported()
+        }
+    }
+
     private val outputSelectCall = OpenDocumentTreeHelper(this) { uri ->
         if (uri != null) {
             val takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
@@ -156,6 +165,11 @@ class BackupsSettingsFragment : Fragment() {
                             showOperationNotSupported()
                         }
                     },
+                    onExportUsagiBackupClick = {
+                        if (!usagiBackupExportCall.tryLaunch(BackupUtils.generateUsagiBackupFileName(requireContext()))) {
+                            showOperationNotSupported()
+                        }
+                    },
                     onRestoreBackupClick = {
                         if (!backupSelectCall.tryLaunch(arrayOf("*/*"))) {
                             showOperationNotSupported()
@@ -194,6 +208,7 @@ fun BackupsSettingsRoute(
     onRestoreBackupClick: () -> Unit,
     onExportMihonBackupClick: () -> Unit,
     onExportAniyomiBackupClick: () -> Unit,
+    onExportUsagiBackupClick: () -> Unit,
     onImportExternalBackupFilePick: (ExternalBackupApp) -> Unit,
 ) {
     val context = LocalContext.current
@@ -337,6 +352,7 @@ fun BackupsSettingsRoute(
         onRestoreBackupClick = onRestoreBackupClick,
         onExportMihonBackupClick = onExportMihonBackupClick,
         onExportAniyomiBackupClick = onExportAniyomiBackupClick,
+        onExportUsagiBackupClick = onExportUsagiBackupClick,
         onImportExternalBackupClick = { isExternalImportDialogVisible = true },
         onDismissExternalImportDialog = { isExternalImportDialogVisible = false },
         onImportExternalBackupAppClick = { app ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -909,6 +909,10 @@
     <string name="export_aniyomi_backup_summary">Export favorites, categories, and reading progress for Mihon manga sources and Aniyomi anime sources.</string>
     <string name="export_aniyomi_backup_saved">Aniyomi backup saved (%1$d entries)</string>
     <string name="export_aniyomi_backup_empty">No compatible Mihon or Aniyomi source favorites or history available to export</string>
+    <string name="export_usagi_backup">Export Usagi backup</string>
+    <string name="export_usagi_backup_summary">Export manga favorites, categories, history, tracking, bookmarks, and statistics for Usagi.</string>
+    <string name="export_usagi_backup_saved">Usagi backup saved (%1$d entries)</string>
+    <string name="export_usagi_backup_empty">No compatible manga favorites or history available to export</string>
     <string name="import_backup_choose_source_app">Choose source app</string>
     <string name="supported_apps">Supported apps</string>
     <string name="import_backup_supported_apps_summary">Mihon, Komikku, Aniyomi, Anikku, Animiru, Venera</string>


### PR DESCRIPTION
Summary of Changes
Data Models (UsagiBackupModels.kt): 
Added @Serializable models matching Usagi's native backup JSON schema (index, categories, favourites, history, bookmarks, sources, scrobbling, statistics).

Export Repository (UsagiBackupExportRepository.kt):
Reads Kototoro user data (favorites, categories, history, bookmarks, tracking scrobblings, and reading statistics).
Filters out non-manga media types (Light Novels and Video/Anime entries).
Preserves all valid manga entries even if Usagi does not have an active parser for that source (Usagi handles missing sources via UnresolvedMangaSource).
Writes all data into a ZIP archive compliant with Usagi's backup reader.

Background Service (UsagiBackupExportService.kt) & Manifest: 
Registered foreground export service with progress tracking and share options.

UI Integration (BackupsSettingsScreen.kt, BackupsSettingsFragment.kt, SettingsActivity.kt): 
Added the "Export Usagi backup" option under the external export section in Settings -> Backups.