### PR TITLE
fix(navigation): fix freeze issue when switching to custom space

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/main/ui/compose/KototoroApp.kt
@@ -705,6 +705,10 @@ fun KototoroApp(
         spaceNavigationSessionUiState.enabled,
         spaceNavigationSessionUiState.restorationReady,
         spaceNavigationSessionUiState.sessions,
+        // A custom navigation state is created lazily when that Space becomes active. Re-run
+        // restoration after switching to it; otherwise the initial built-in Space pass skips it
+        // and the covered Space transition can never become ready to reveal.
+        navigationSpaceId,
     ) {
         if (!spaceNavigationSessionUiState.enabled) {
             restoredSpaceIds.clear()


### PR DESCRIPTION
## Issue

When you switch from a built-in Space to a custom Space, the transition screen freezes, and the Space entries in the sidebar become unresponsive. See the screenshot below.

> 从预设 Space 切换到自定义 Space 后，直接卡死在切换过渡界面，且侧栏的 Space 项目无法操作。如下图。

<img width="320" alt="Screenshot_2026-08-05-14-05-51-253_org skepsun kototoro" src="https://github.com/user-attachments/assets/237ef26a-5f7c-4ccd-85e0-bb6090f4366e" />

## Cause

A custom navigation state is created lazily when that Space becomes active. However when switching to a custom Space, the restoration effect does not re-run, causing the transition screen to remain in the COVERED state and the sidebar to become unresponsive.

> 自定义 Space 的导航状态是懒加载创建的。但切换到自定义 Space 后，恢复 session 的逻辑没有重新执行，导致过渡界面一直停留在 COVERED 状态，侧栏也无法操作。

## Fix

Include `navigationSpaceId` in the trigger conditions for restoring the session.

> 将 navigationSpaceId 加入恢复 session 的触发条件。
