### PR TITLE
feat(sources): add buttons to enable/disable all sources filtered

### DIFF
--- a/app/src/main/kotlin/org/skepsun/kototoro/settings/sources/unified/UnifiedSourcesScreen.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/settings/sources/unified/UnifiedSourcesScreen.kt
@@ -164,6 +164,10 @@ private sealed interface UnifiedSourcesDialogState {
 	data class TrustRepository(val repo: ExternalExtensionRepo) : UnifiedSourcesDialogState
 	data class DeleteRepository(val repository: UnifiedSourceRepositoryItem) : UnifiedSourcesDialogState
 	data class DeleteSelectedSources(val plan: UnifiedSelectedSourceDeletePlan) : UnifiedSourcesDialogState
+	data class SetFilteredSourcesEnabled(
+		val sourceIds: Set<String>,
+		val enabled: Boolean,
+	) : UnifiedSourcesDialogState
 	data class PackageDetails(val item: UnifiedSourcePackageItem) : UnifiedSourcesDialogState
 	data class ThirdPartyDisclaimer(val action: UnifiedThirdPartyAction) : UnifiedSourcesDialogState
 }
@@ -263,6 +267,16 @@ fun UnifiedSourcesRoute(
 		initialRepositoryHandled = true
 	}
 
+	fun confirmSetFilteredSourcesEnabled(enabled: Boolean) {
+		val sourceIds = (state as? UnifiedSourcesUiState.Ready)
+			?.sources
+			.orEmpty()
+			.mapTo(LinkedHashSet()) { it.id }
+		if (sourceIds.isNotEmpty()) {
+			activeDialog = UnifiedSourcesDialogState.SetFilteredSourcesEnabled(sourceIds, enabled)
+		}
+	}
+
 	UnifiedSourcesScreen(
 		state = state,
 		isLoading = isLoading,
@@ -279,6 +293,8 @@ fun UnifiedSourcesRoute(
 		onLanguageFilterClick = { onActivePanelChange(UnifiedToolbarFilterPanel.LANGUAGE) },
 		onMoreFiltersClick = { onActivePanelChange(UnifiedToolbarFilterPanel.MORE) },
 		onSourceEnabledChange = viewModel::setSourceEnabled,
+		onEnableAllSources = { confirmSetFilteredSourcesEnabled(true) },
+		onDisableAllSources = { confirmSetFilteredSourcesEnabled(false) },
 		selectedSourceIds = selectedSourceIds,
 		onSourceSelectionChange = { selectedSourceIdList = it.toList() },
 		onSelectAllVisibleSources = {
@@ -485,6 +501,16 @@ fun UnifiedSourcesRoute(
 			},
 		)
 
+		is UnifiedSourcesDialogState.SetFilteredSourcesEnabled -> UnifiedSetFilteredSourcesEnabledDialog(
+			enabled = dialog.enabled,
+			sourceCount = dialog.sourceIds.size,
+			onDismiss = { activeDialog = null },
+			onConfirm = {
+				viewModel.setSourcesEnabled(dialog.sourceIds, dialog.enabled)
+				activeDialog = null
+			},
+		)
+
 		is UnifiedSourcesDialogState.DeleteSelectedSources -> UnifiedDeleteSelectedSourcesDialog(
 			plan = dialog.plan,
 			onDismiss = { activeDialog = null },
@@ -682,6 +708,49 @@ private fun UnifiedDeleteRepositoryDialog(
 			)
 		},
 		text = { Text(stringResource(R.string.delete_repository_message, repository.name)) },
+	)
+}
+
+@Composable
+private fun UnifiedSetFilteredSourcesEnabledDialog(
+	enabled: Boolean,
+	sourceCount: Int,
+	onDismiss: () -> Unit,
+	onConfirm: () -> Unit,
+) {
+	SettingsAlertDialog(
+		title = stringResource(
+			if (enabled) {
+				R.string.unified_sources_enable_all
+			} else {
+				R.string.unified_sources_disable_all
+			},
+		),
+		onDismissRequest = onDismiss,
+		confirmButton = {
+			SettingsDialogActionButton(
+				text = stringResource(if (enabled) R.string.enable else R.string.disable),
+				onClick = onConfirm,
+			)
+		},
+		dismissButton = {
+			SettingsDialogActionButton(
+				text = stringResource(android.R.string.cancel),
+				onClick = onDismiss,
+			)
+		},
+		text = {
+			Text(
+				stringResource(
+					if (enabled) {
+						R.string.unified_sources_enable_all_confirmation
+					} else {
+						R.string.unified_sources_disable_all_confirmation
+					},
+					sourceCount,
+				),
+			)
+		},
 	)
 }
 
@@ -1134,6 +1203,8 @@ fun UnifiedSourcesScreen(
 	onKindClick: (UnifiedSourceKind?) -> Unit,
 	onContentTypeClick: (ContentType?) -> Unit,
 	onSourceEnabledChange: (String, Boolean) -> Unit,
+	onEnableAllSources: () -> Unit,
+	onDisableAllSources: () -> Unit,
 	selectedSourceIds: Set<String>,
 	onSourceSelectionChange: (Set<String>) -> Unit,
 	onSelectAllVisibleSources: () -> Unit,
@@ -1275,6 +1346,8 @@ fun UnifiedSourcesScreen(
 									onBrowseSource = onBrowseSource,
 									onOpenSourceSettings = onOpenSourceSettings,
 									onSourceEnabledChange = onSourceEnabledChange,
+									onEnableAllSources = onEnableAllSources,
+									onDisableAllSources = onDisableAllSources,
 									selectedSourceIds = activeSelectedSourceIds,
 									onSourceSelectionChange = onSourceSelectionChange,
 									onSourcePinnedChange = onSourcePinnedChange,
@@ -1474,6 +1547,8 @@ private fun UnifiedSourceList(
 	onBrowseSource: (UnifiedSourceItem) -> Unit,
 	onOpenSourceSettings: (UnifiedSourceItem) -> Unit,
 	onSourceEnabledChange: (String, Boolean) -> Unit,
+	onEnableAllSources: () -> Unit,
+	onDisableAllSources: () -> Unit,
 	selectedSourceIds: Set<String>,
 	onSourceSelectionChange: (Set<String>) -> Unit,
 	onSourcePinnedChange: (String, Boolean) -> Unit,
@@ -1487,6 +1562,29 @@ private fun UnifiedSourceList(
 			vertical = 4.dp,
 		),
 	) {
+		item(key = "source_actions") {
+			LazyRow(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(bottom = 4.dp),
+				horizontalArrangement = Arrangement.spacedBy(8.dp),
+			) {
+				item(key = "enable_all_sources") {
+					CompactActionChip(
+						onClick = onEnableAllSources,
+						enabled = sources.isNotEmpty(),
+						label = { Text(stringResource(R.string.unified_sources_enable_all)) },
+					)
+				}
+				item(key = "disable_all_sources") {
+					CompactActionChip(
+						onClick = onDisableAllSources,
+						enabled = sources.isNotEmpty(),
+						label = { Text(stringResource(R.string.unified_sources_disable_all)) },
+					)
+				}
+			}
+		}
 		items(sources, key = { it.id }) { item ->
 			val isSelected = item.id in selectedSourceIds
 			UnifiedSourceRow(
@@ -2135,9 +2233,11 @@ private fun CompactActionChip(
 	onClick: () -> Unit,
 	label: @Composable () -> Unit,
 	modifier: Modifier = Modifier,
+	enabled: Boolean = true,
 ) {
 	AssistChip(
 		onClick = onClick,
+		enabled = enabled,
 		modifier = modifier.defaultMinSize(minHeight = 30.dp),
 		label = {
 			Box(modifier = Modifier.padding(horizontal = 2.dp)) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2712,6 +2712,10 @@ SHA-256 指纹:
     <string name="unified_sources_cannot_open_selected_jar">无法打开选定的 JAR 文件</string>
     <string name="unified_sources_delete_selected_message">删除选中的 %1$d 个扩展包？</string>
     <string name="unified_sources_delete_selected_no_packages">当前选择中未找到可删除的扩展包。</string>
+    <string name="unified_sources_enable_all">全部启用</string>
+    <string name="unified_sources_disable_all">全部禁用</string>
+    <string name="unified_sources_enable_all_confirmation">启用当前筛选结果中的 %1$d 个源？</string>
+    <string name="unified_sources_disable_all_confirmation">禁用当前筛选结果中的 %1$d 个源？</string>
     <string name="unified_sources_delete_selected_only_skipped_jars">选择中包含 JAR 源。为避免意外删除，已跳过其扩展包: %1$s</string>
     <string name="unified_sources_delete_selected_with_skipped_jars">删除选中的 %1$d 个扩展包？
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2697,6 +2697,10 @@
     <string name="unified_sources_delete_selected_with_skipped_jars">Delete %1$d package(s) for the selected sources?\n\nJAR packages were skipped to avoid accidental removal: %2$s</string>
     <string name="unified_sources_delete_selected_only_skipped_jars">The selection contains JAR sources. Their packages were skipped to avoid accidental removal: %1$s</string>
     <string name="unified_sources_delete_selected_no_packages">No removable packages were found in the current selection.</string>
+    <string name="unified_sources_enable_all">Enable all</string>
+    <string name="unified_sources_disable_all">Disable all</string>
+    <string name="unified_sources_enable_all_confirmation">Enable all %1$d sources in the current filter?</string>
+    <string name="unified_sources_disable_all_confirmation">Disable all %1$d sources in the current filter?</string>
     <string name="show_extensions_in_grid">Show extensions in two columns</string>
     <string name="show_extensions_in_list">Show extensions in one column</string>
     <string name="setup_wizard">Setup wizard</string>


### PR DESCRIPTION
Closes #479 

## Description

- Adds two buttons, "Enable All" and "Disable All", to the top of the "Sources" list. 
- These buttons will only affect the currently filtered results. 
- When clicked, a confirmation dialog will appear, showing the number of sources that will be affected. 
- If there are no filtered results, the buttons will be disabled.