### PR TITLE
fix: complete Cloudflare browser verification automatically

### DIFF
--- a/app/src/androidTest/kotlin/org/skepsun/kototoro/core/nav/AppRouterCloudFlareIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/skepsun/kototoro/core/nav/AppRouterCloudFlareIntentTest.kt
@@ -1,0 +1,58 @@
+package org.skepsun.kototoro.core.nav
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import okhttp3.Headers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.skepsun.kototoro.R
+import org.skepsun.kototoro.browser.BrowserActivity
+import org.skepsun.kototoro.core.exceptions.CloudFlareProtectedException
+import org.skepsun.kototoro.core.model.TestContentSource
+
+@RunWith(AndroidJUnit4::class)
+class AppRouterCloudFlareIntentTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun cloudFlareResolveIntent_includesClearanceCookieContractAndNavigationMetadata() {
+        val intent = AppRouter.cloudFlareResolveIntent(
+            context,
+            cloudFlareException("https://reader.example.com/protected/chapter?token=secret"),
+        )
+        val challengeUrl = "https://reader.example.com/"
+
+        assertEquals(BrowserActivity::class.java.name, intent.component?.className)
+        assertEquals(challengeUrl, intent.dataString)
+        assertEquals(challengeUrl, intent.getStringExtra(AppRouter.KEY_SUCCESS_COOKIE_URL))
+        assertEquals("cf_clearance", intent.getStringExtra(AppRouter.KEY_SUCCESS_COOKIE_NAME))
+        assertEquals(TestContentSource.name, intent.getStringExtra(AppRouter.KEY_SOURCE))
+        assertEquals("test-user-agent", intent.getStringExtra(AppRouter.KEY_USER_AGENT))
+        assertEquals(
+            context.getString(R.string.open_in_reader_browser),
+            intent.getStringExtra(AppRouter.KEY_TITLE),
+        )
+    }
+
+    @Test
+    fun cloudFlareResolveIntent_usesRootDomainForAssetDataAndCookieUrl() {
+        val intent = AppRouter.cloudFlareResolveIntent(
+            context,
+            cloudFlareException("https://cdn.example.com/covers/chapter.webp?token=secret"),
+        )
+        val challengeUrl = "https://example.com/"
+
+        assertEquals(challengeUrl, intent.dataString)
+        assertEquals(challengeUrl, intent.getStringExtra(AppRouter.KEY_SUCCESS_COOKIE_URL))
+        assertEquals("cf_clearance", intent.getStringExtra(AppRouter.KEY_SUCCESS_COOKIE_NAME))
+    }
+
+    private fun cloudFlareException(url: String) = CloudFlareProtectedException(
+        url = url,
+        source = TestContentSource,
+        headers = Headers.headersOf("User-Agent", "test-user-agent"),
+    )
+}

--- a/app/src/main/kotlin/org/skepsun/kototoro/browser/BrowserActivity.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/browser/BrowserActivity.kt
@@ -137,12 +137,7 @@ class BrowserActivity : BaseBrowserActivity() {
         logCookieState("finish", currentValue)
         pendingResult = if (isSuccessCookieSatisfied(currentValue)) RESULT_OK else RESULT_CANCELED
         setResult(pendingResult)
-        if (!cfResolveResultNotified) {
-            cfResolveResultNotified = true
-            intent?.getStringExtra(EXTRA_CF_RESOLVE_KEY)?.let { resolveKey ->
-                captchaAutoResolveCoordinator.notifyResolveResult(resolveKey, pendingResult == RESULT_OK)
-            }
-        }
+        notifyCfResolveResult()
         super.finish()
     }
 
@@ -310,7 +305,16 @@ class BrowserActivity : BaseBrowserActivity() {
 
     private fun superFinishAfterVerification() {
         setResult(pendingResult)
+        notifyCfResolveResult()
         super.finish()
+    }
+
+    private fun notifyCfResolveResult() {
+        if (cfResolveResultNotified) return
+        cfResolveResultNotified = true
+        intent?.getStringExtra(EXTRA_CF_RESOLVE_KEY)?.let { resolveKey ->
+            captchaAutoResolveCoordinator.notifyResolveResult(resolveKey, pendingResult == RESULT_OK)
+        }
     }
 
     private suspend fun completeBrowserWait() {

--- a/app/src/main/kotlin/org/skepsun/kototoro/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/skepsun/kototoro/core/nav/AppRouter.kt
@@ -1412,14 +1412,19 @@ class AppRouter(
         fun cloudFlareResolveIntent(
             context: Context,
             exception: CloudFlareProtectedException,
-        ): Intent = browserIntent(
-            context = context,
-            url = CloudFlareHelper.getChallengeUrl(exception.url),
-            source = exception.source,
-            title = context.getString(R.string.open_in_reader_browser),
-        ).apply {
-            exception.headers[CommonHeaders.USER_AGENT]?.let {
-                putExtra(KEY_USER_AGENT, it)
+        ): Intent {
+            val challengeUrl = CloudFlareHelper.getChallengeUrl(exception.url)
+            return browserIntent(
+                context = context,
+                url = challengeUrl,
+                source = exception.source,
+                title = context.getString(R.string.open_in_reader_browser),
+            ).apply {
+                putExtra(KEY_SUCCESS_COOKIE_URL, challengeUrl)
+                putExtra(KEY_SUCCESS_COOKIE_NAME, "cf_clearance")
+                exception.headers[CommonHeaders.USER_AGENT]?.let {
+                    putExtra(KEY_USER_AGENT, it)
+                }
             }
         }
 


### PR DESCRIPTION
Update `AppRouter.cloudFlareResolveIntent` to attach the normalized challenge URL as `KEY_SUCCESS_COOKIE_URL` and `cf_clearance` as `KEY_SUCCESS_COOKIE_NAME` while preserving its existing source, title, and user-agent extras. This lets the shipped `BrowserActivity` compare the initial cookie with the newly issued clearance, automatically finish after the checkbox challenge succeeds, flush the WebView cookie store, and report success to the coordinator so the original request is retried. Issue #478 reports that completing a Cloudflare checkbox in Kototoro does not finish the browser flow automatically and that the clearance is not reliably reused after the app is reopened. The current `BrowserActivity` already supports watching for a named success cookie, flushing WebView cookies, returning success, and notifying `CaptchaAutoResolveCoordinator`, but `AppRouter.cloudFlareResolveIntent` does not provide the success-cookie URL or name.

Build a Cloudflare exception for a normal protected page and verify the generated intent targets `BrowserActivity`, loads the normalized challenge URL, and includes `KEY_SUCCESS_COOKIE_URL` for that same URL plus `KEY_SUCCESS_COOKIE_NAME` equal to `cf_clearance`; Build an exception whose detected URL is an asset/CDN URL and verify the intent uses the existing root-domain normalization consistently for both its data URI and success-cookie URL.

Closes #478
